### PR TITLE
[RediSearch] Fixing unkown arguments and some more stuff

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ export { RedisBloomCuckoo, CFInsertParameters, CFResponse, CFReserveParameters }
 export { RedisBloomCMK, CMKIncrbyItems } from './modules/redisbloom-cmk';
 export {
     RedisTimeSeries as RTS, RedisTimeSeries, TSCreateOptions, TSLabel, TSAddOptions, TSKeySet, TSIncrbyDecrbyOptions, TSOptions, TSCreateRule, TSAggregationType,
-    TSRangeOptions, TSMRangeOptions, TSInfo
+    TSRangeOptions, TSMRangeOptions, TSInfo, TSAlignType
 } from './modules/rts';
 export {
     Redisearch, FTCreateParameters, FTFieldOptions, FTSchemaField, FTSearchParameters, FTAggregateParameters, FTSugAddParameters, FTSugGetParameters, FTSpellCheck,

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -96,7 +96,7 @@ export class Module {
      * @param response The array response from the module
      * @param returnSingleDimensionArray If we should return single dimension arrays without parsing them to objects
      */
-    handleResponse(response: any, returnSingleDimensionArray: boolean = false): any {
+    handleResponse(response: any, returnSingleDimensionArray = false): any {
         const obj = {}
         //If not an array/object
         if (

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -98,75 +98,68 @@ export class Module {
      */
     handleResponse(response: any, isSearchQuery = false): any {
         //If not an array/object
-        try {
-            if(
-                (typeof response === 'string' ||
-                typeof response === 'number' ||
-                (Array.isArray(response) && response.length % 2 === 1 && response.length > 1 && !this.isOnlyTwoDimensionalArray(response)) ||
-                (Array.isArray(response) && response.length === 0)) &&
-                !isSearchQuery
-            ) {
-                return response;
-            }
-            else if(Array.isArray(response) && response.length === 1) {
-                return this.handleResponse(response[0])
-            }
-            else if(isSearchQuery) {
-                    //Search queries should be parsed into objects, if possible.
-                    let responseObjects = response;
-                    if(Array.isArray(response) && response.length % 2 === 1) {
-                        // Put index as 0th element
-                        responseObjects = [response[0]];
-                        // Go through returned keys (doc:1, doc:2, ...)
-                        for(let i = 1; i < response.length; i += 2) {
-                            // propertyArray is the key-value pairs eg: ['name', 'John']
-                            const propertyArray = response[i+1];
-                            responseObjects.push({
-                                key: response[i] //This is the key, 'eg doc:1'
-                            });
-                        
-                            if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
-                                for(let j = 0; j < propertyArray.length; j += 2){
-                                    // Add keys to last responseObjects item
-                                    // propertyArray[j] = key name
-                                    // propertyArray[j+1] = value
-                                    responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
-                                }
+        if(
+            (typeof response === 'string' ||
+            typeof response === 'number' ||
+            (Array.isArray(response) && response.length % 2 === 1 && response.length > 1 && !this.isOnlyTwoDimensionalArray(response)) ||
+            (Array.isArray(response) && response.length === 0)) &&
+            !isSearchQuery
+        ) {
+            return response;
+        }
+        else if(Array.isArray(response) && response.length === 1) {
+            return this.handleResponse(response[0])
+        }
+        else if(isSearchQuery) {
+                //Search queries should be parsed into objects, if possible.
+                let responseObjects = response;
+                if(Array.isArray(response) && response.length % 2 === 1) {
+                    // Put index as 0th element
+                    responseObjects = [response[0]];
+                    // Go through returned keys (doc:1, doc:2, ...)
+                    for(let i = 1; i < response.length; i += 2) {
+                        // propertyArray is the key-value pairs eg: ['name', 'John']
+                        const propertyArray = response[i+1];
+                        responseObjects.push({
+                            key: response[i] //This is the key, 'eg doc:1'
+                        });
+                        if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
+                            for(let j = 0; j < propertyArray.length; j += 2){
+                                // Add keys to last responseObjects item
+                                // propertyArray[j] = key name
+                                // propertyArray[j+1] = value
+                                responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
                             }
                         }
                     }
-                    //Check for a single dimensional array, these should only be keys, if im right
-                    else if(response.every(entry => !Array.isArray(entry))) {
-                        responseObjects = [response[0]];
-                        for(let i = 1; i < response.length; i ++) {
-                            responseObjects.push({
-                                key: response[i],
-                            });
-                        }
-                    }
-                    return responseObjects;
-            }
-            else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
-                return this.handleResponse(this.reduceArrayDimension(response))
-            }
-        
-            const obj = {}
-            //If is an array/obj we will build it
-            for(let i = 0; i < response.length; i += 2) {
-                if(response[i + 1] !== '' && response[i + 1] !== undefined) {
-                    if(Array.isArray(response[i + 1]) && this.isOnlyTwoDimensionalArray(response[i + 1])) {
-                        obj[response[i]] = this.reduceArrayDimension(response[i + 1]);
-                        continue;
-                    }
-                    const value = (Array.isArray(response[i + 1]) ? this.handleResponse(response[i + 1]) : response[i + 1])
-                    obj[response[i]] = value;
                 }
-            }
-            return obj
-        } catch(err) {
-            // console.log(this.handleError('An error occurred while parsing response\n' + err));
-            return response;
+                //Check for a single dimensional array, these should only be keys, if im right
+                else if(response.every(entry => !Array.isArray(entry))) {
+                    responseObjects = [response[0]];
+                    for(let i = 1; i < response.length; i ++) {
+                        responseObjects.push({
+                            key: response[i],
+                        });
+                    }
+                }
+                return responseObjects;
         }
+        else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
+            return this.handleResponse(this.reduceArrayDimension(response))
+        }
+        const obj = {}
+        //If is an array/obj we will build it
+        for(let i = 0; i < response.length; i += 2) {
+            if(response[i + 1] !== '' && response[i + 1] !== undefined) {
+                if(Array.isArray(response[i + 1]) && this.isOnlyTwoDimensionalArray(response[i + 1])) {
+                    obj[response[i]] = this.reduceArrayDimension(response[i + 1]);
+                    continue;
+                }
+                const value = (Array.isArray(response[i + 1]) ? this.handleResponse(response[i + 1]) : response[i + 1])
+                obj[response[i]] = value;
+            }
+        }
+        return obj
     }
 
     /**

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -113,7 +113,6 @@ export class Module {
         else if(isSearchQuery) {
             //Search queries should be parsed into objects, if possible.
             let responseObjects = response;
-            console.log(responseObjects);
             if(Array.isArray(response) && response.length % 2 === 1) {
                 // Put index as 0th element
                 responseObjects = [response[0]];

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -98,75 +98,75 @@ export class Module {
      */
     handleResponse(response: any, isSearchQuery = false): any {
         //If not an array/object
-        if(
-            (typeof response === 'string' ||
-            typeof response === 'number' ||
-            (Array.isArray(response) && response.length % 2 === 1 && response.length > 1 && !this.isOnlyTwoDimensionalArray(response)) ||
-            (Array.isArray(response) && response.length === 0)) &&
-            !isSearchQuery
-        ) {
-            return response;
-        }
-        else if(Array.isArray(response) && response.length === 1) {
-            return this.handleResponse(response[0])
-        }
-        else if(isSearchQuery) {
-            try {
-                //Search queries should be parsed into objects, if possible.
-                let responseObjects = response;
-                if(Array.isArray(response) && response.length % 2 === 1) {
-                    // Put index as 0th element
-                    responseObjects = [response[0]];
-                    // Go through returned keys (doc:1, doc:2, ...)
-                    for(let i = 1; i < response.length; i += 2) {
-                        // propertyArray is the key-value pairs eg: ['name', 'John']
-                        const propertyArray = response[i+1];
-                        responseObjects.push({
-                            key: response[i] //This is the key, 'eg doc:1'
-                        });
-
-                        if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
-                            for(let j = 0; j < propertyArray.length; j += 2){
-                                // Add keys to last responseObjects item
-                                // propertyArray[j] = key name
-                                // propertyArray[j+1] = value
-                                responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
+        try {
+            if(
+                (typeof response === 'string' ||
+                typeof response === 'number' ||
+                (Array.isArray(response) && response.length % 2 === 1 && response.length > 1 && !this.isOnlyTwoDimensionalArray(response)) ||
+                (Array.isArray(response) && response.length === 0)) &&
+                !isSearchQuery
+            ) {
+                return response;
+            }
+            else if(Array.isArray(response) && response.length === 1) {
+                return this.handleResponse(response[0])
+            }
+            else if(isSearchQuery) {
+                    //Search queries should be parsed into objects, if possible.
+                    let responseObjects = response;
+                    if(Array.isArray(response) && response.length % 2 === 1) {
+                        // Put index as 0th element
+                        responseObjects = [response[0]];
+                        // Go through returned keys (doc:1, doc:2, ...)
+                        for(let i = 1; i < response.length; i += 2) {
+                            // propertyArray is the key-value pairs eg: ['name', 'John']
+                            const propertyArray = response[i+1];
+                            responseObjects.push({
+                                key: response[i] //This is the key, 'eg doc:1'
+                            });
+                        
+                            if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
+                                for(let j = 0; j < propertyArray.length; j += 2){
+                                    // Add keys to last responseObjects item
+                                    // propertyArray[j] = key name
+                                    // propertyArray[j+1] = value
+                                    responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
+                                }
                             }
                         }
                     }
-                }
-                //Check for a single dimensional array, these should only be keys, if im right
-                else if(response.every(entry => !Array.isArray(entry))) {
-                    responseObjects = [response[0]];
-                    for(let i = 1; i < response.length; i ++) {
-                        responseObjects.push({
-                            key: response[i],
-                        });
+                    //Check for a single dimensional array, these should only be keys, if im right
+                    else if(response.every(entry => !Array.isArray(entry))) {
+                        responseObjects = [response[0]];
+                        for(let i = 1; i < response.length; i ++) {
+                            responseObjects.push({
+                                key: response[i],
+                            });
+                        }
                     }
-                }
-                return responseObjects;
-            } catch(err) {
-                // console.log(this.handleError('An error occurred while parsing response\n' + err));
-                return response;
+                    return responseObjects;
             }
-        }
-        else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
-            return this.handleResponse(this.reduceArrayDimension(response))
-        }
-
-        const obj = {}
-        //If is an array/obj we will build it
-        for(let i = 0; i < response.length; i += 2) {
-            if(response[i + 1] !== '' && response[i + 1] !== undefined) {
-                if(Array.isArray(response[i + 1]) && this.isOnlyTwoDimensionalArray(response[i + 1])) {
-                    obj[response[i]] = this.reduceArrayDimension(response[i + 1]);
-                    continue;
-                }
-                const value = (Array.isArray(response[i + 1]) ? this.handleResponse(response[i + 1]) : response[i + 1])
-                obj[response[i]] = value;
+            else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
+                return this.handleResponse(this.reduceArrayDimension(response))
             }
+        
+            const obj = {}
+            //If is an array/obj we will build it
+            for(let i = 0; i < response.length; i += 2) {
+                if(response[i + 1] !== '' && response[i + 1] !== undefined) {
+                    if(Array.isArray(response[i + 1]) && this.isOnlyTwoDimensionalArray(response[i + 1])) {
+                        obj[response[i]] = this.reduceArrayDimension(response[i + 1]);
+                        continue;
+                    }
+                    const value = (Array.isArray(response[i + 1]) ? this.handleResponse(response[i + 1]) : response[i + 1])
+                    obj[response[i]] = value;
+                }
+            }
+            return obj
+        } catch(err) {
+            // console.log(this.handleError('An error occurred while parsing response\n' + err));
+            return response;
         }
-        return obj
     }
 
     /**

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -111,39 +111,44 @@ export class Module {
             return this.handleResponse(response[0])
         }
         else if(isSearchQuery) {
-            //Search queries should be parsed into objects, if possible.
-            let responseObjects = response;
-            if(Array.isArray(response) && response.length % 2 === 1) {
-                // Put index as 0th element
-                responseObjects = [response[0]];
-                // Go through returned keys (doc:1, doc:2, ...)
-                for(let i = 1; i < response.length; i += 2) {
-                    // propertyArray is the key-value pairs eg: ['name', 'John']
-                    const propertyArray = response[i+1];
-                    responseObjects.push({
-                        key: response[i] //This is the key, 'eg doc:1'
-                    });
-                    
-                    if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
-                        for(let j = 0; j < propertyArray.length; j += 2){
-                            // Add keys to last responseObjects item
-                            // propertyArray[j] = key name
-                            // propertyArray[j+1] = value
-                            responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
+            try {
+                //Search queries should be parsed into objects, if possible.
+                let responseObjects = response;
+                if(Array.isArray(response) && response.length % 2 === 1) {
+                    // Put index as 0th element
+                    responseObjects = [response[0]];
+                    // Go through returned keys (doc:1, doc:2, ...)
+                    for(let i = 1; i < response.length; i += 2) {
+                        // propertyArray is the key-value pairs eg: ['name', 'John']
+                        const propertyArray = response[i+1];
+                        responseObjects.push({
+                            key: response[i] //This is the key, 'eg doc:1'
+                        });
+
+                        if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
+                            for(let j = 0; j < propertyArray.length; j += 2){
+                                // Add keys to last responseObjects item
+                                // propertyArray[j] = key name
+                                // propertyArray[j+1] = value
+                                responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
+                            }
                         }
                     }
                 }
-            }
-            //Check for a single dimensional array, these should only be keys, if im right
-            else if(response.every(entry => !Array.isArray(entry))) {
-                responseObjects = [response[0]];
-                for(let i = 1; i < response.length; i ++) {
-                    responseObjects.push({
-                        key: response[i],
-                    });
+                //Check for a single dimensional array, these should only be keys, if im right
+                else if(response.every(entry => !Array.isArray(entry))) {
+                    responseObjects = [response[0]];
+                    for(let i = 1; i < response.length; i ++) {
+                        responseObjects.push({
+                            key: response[i],
+                        });
+                    }
                 }
+                return responseObjects;
+            } catch(err) {
+                // console.log(this.handleError('An error occurred while parsing response\n' + err));
+                return response;
             }
-            return responseObjects;
         }
         else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
             return this.handleResponse(this.reduceArrayDimension(response))

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -20,7 +20,7 @@ export class Module {
      * @param moduleOptions.showDebugLogs If to print debug logs
      * @param clusterOptions The options of the clusters
      */
-    constructor(name: string, clusterNodes: IORedis.ClusterNode[], moduleOptions?: RedisModuleOptions, clusterOptions?: IORedis.ClusterOptions,)
+    constructor(name: string, clusterNodes: IORedis.ClusterNode[], moduleOptions?: RedisModuleOptions, clusterOptions?: IORedis.ClusterOptions, )
     /**
      * Initializing the module object
      * @param name The name of the module
@@ -33,7 +33,7 @@ export class Module {
     constructor(name: string, options: IORedis.RedisOptions | IORedis.ClusterNode[], moduleOptions?: RedisModuleOptions, clusterOptions?: IORedis.ClusterOptions) {
         this.name = name;
         //If it's a list of cluster nodes
-        if (Array.isArray(options))
+        if(Array.isArray(options))
             this.clusterNodes = options as IORedis.ClusterNode[];
         else
             this.redisOptions = options as IORedis.RedisOptions;
@@ -46,7 +46,7 @@ export class Module {
      * Connecting to the Redis database with the module
      */
     async connect(): Promise<void> {
-        if (this.clusterNodes)
+        if(this.clusterNodes)
             this.cluster = new IORedis.Cluster(this.clusterNodes, this.clusterOptions);
         else
             this.redis = new IORedis(this.redisOptions);
@@ -56,7 +56,7 @@ export class Module {
      * Disconnecting from the Redis database with the module
      */
     async disconnect(): Promise<void> {
-        if (this.clusterNodes)
+        if(this.clusterNodes)
             await this.cluster.quit();
         else
             await this.redis.quit();
@@ -69,13 +69,13 @@ export class Module {
      */
     async sendCommand(command: string, args: IORedis.ValueType | IORedis.ValueType[] = []): Promise<any> {
         try {
-            if (this.showDebugLogs)
+            if(this.showDebugLogs)
                 console.log(`${this.name}: Running command ${command} with arguments: ${args}`);
             const response = this.clusterNodes ? await this.cluster.cluster.call(command, args) : await this.redis.send_command(command, args);
-            if (this.showDebugLogs)
+            if(this.showDebugLogs)
                 console.log(`${this.name}: command ${command} responded with ${response}`);
             return response;
-        } catch (error) {
+        } catch(error) {
             return this.handleError(`${this.name} class (${command.split(' ')[0]}): ${error}`)
         }
     }
@@ -86,7 +86,7 @@ export class Module {
      * @param error The message of the error
      */
     handleError(error: string): any {
-        if (this.isHandleError)
+        if(this.isHandleError)
             throw new Error(error);
         return error;
     }
@@ -99,7 +99,7 @@ export class Module {
     handleResponse(response: any, returnSingleDimensionArray = false): any {
         const obj = {}
         //If not an array/object
-        if (
+        if(
             typeof response === 'string' ||
             typeof response === 'number' ||
             (Array.isArray(response) && response.length % 2 === 1 && response.length > 1 && !this.isOnlyTwoDimensionalArray(response)) ||
@@ -107,23 +107,23 @@ export class Module {
         ) {
             return response;
         }
-        else if (Array.isArray(response) && response.length === 1) {
+        else if(Array.isArray(response) && response.length === 1){
             return this.handleResponse(response[0])
-        } else if (Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
+        }else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)){
             return this.handleResponse(this.reduceArrayDimension(response))
-        } else if (returnSingleDimensionArray && Array.isArray(response) && response.every(entry => !Array.isArray(entry))){
+        }else if(returnSingleDimensionArray && Array.isArray(response) && response.every(entry => !Array.isArray(entry))){
             //Return single dimension arrays
             return response;
         }
         
         //If is an array/obj we will build it
-        for (let i = 0; i < response.length; i += 2) {
-            if (response[i + 1] !== '' && response[i + 1] !== undefined) {
-                if (Array.isArray(response[i + 1]) && this.isOnlyTwoDimensionalArray(response[i + 1])) {
-                    obj[response[i]] = this.reduceArrayDimension(response[i + 1]);
+        for (let i = 0; i < response.length; i+=2) {
+            if (response[i+1] !== '' && response[i+1] !== undefined) {
+                if(Array.isArray(response[i+1]) && this.isOnlyTwoDimensionalArray(response[i+1])) {
+                    obj[response[i]] = this.reduceArrayDimension(response[i+1]);
                     continue;
                 }
-                const value = (Array.isArray(response[i + 1]) ? this.handleResponse(response[i + 1]) : response[i + 1])
+                const value = (Array.isArray(response[i+1]) ? this.handleResponse(response[i+1]) : response[i+1])
                 obj[response[i]] = value;
             }
         }

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -117,8 +117,8 @@ export class Module {
         }
         
         //If is an array/obj we will build it
-        for (let i = 0; i < response.length; i+=2) {
-            if (response[i+1] !== '' && response[i+1] !== undefined) {
+        for(let i = 0; i < response.length; i+=2) {
+            if(response[i+1] !== '' && response[i+1] !== undefined) {
                 if(Array.isArray(response[i+1]) && this.isOnlyTwoDimensionalArray(response[i+1])) {
                     obj[response[i]] = this.reduceArrayDimension(response[i+1]);
                     continue;

--- a/modules/module.base.ts
+++ b/modules/module.base.ts
@@ -111,38 +111,38 @@ export class Module {
             return this.handleResponse(response[0])
         }
         else if(isSearchQuery) {
-                //Search queries should be parsed into objects, if possible.
-                let responseObjects = response;
-                if(Array.isArray(response) && response.length % 2 === 1) {
-                    // Put index as 0th element
-                    responseObjects = [response[0]];
-                    // Go through returned keys (doc:1, doc:2, ...)
-                    for(let i = 1; i < response.length; i += 2) {
-                        // propertyArray is the key-value pairs eg: ['name', 'John']
-                        const propertyArray = response[i+1];
-                        responseObjects.push({
-                            key: response[i] //This is the key, 'eg doc:1'
-                        });
-                        if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
-                            for(let j = 0; j < propertyArray.length; j += 2){
-                                // Add keys to last responseObjects item
-                                // propertyArray[j] = key name
-                                // propertyArray[j+1] = value
-                                responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j+1];
-                            }
+            //Search queries should be parsed into objects, if possible.
+            let responseObjects = response;
+            if(Array.isArray(response) && response.length % 2 === 1) {
+                // Put index as 0th element
+                responseObjects = [response[0]];
+                // Go through returned keys (doc:1, doc:2, ...)
+                for(let i = 1; i < response.length; i += 2) {
+                    // propertyArray is the key-value pairs eg: ['name', 'John']
+                    const propertyArray = response[i + 1];
+                    responseObjects.push({
+                        key: response[i] //This is the key, 'eg doc:1'
+                    });
+                    if(Array.isArray(propertyArray) && propertyArray.length % 2 === 0) {
+                        for(let j = 0; j < propertyArray.length; j += 2) {
+                            // Add keys to last responseObjects item
+                            // propertyArray[j] = key name
+                            // propertyArray[j+1] = value
+                            responseObjects[responseObjects.length - 1][propertyArray[j]] = propertyArray[j + 1];
                         }
                     }
                 }
-                //Check for a single dimensional array, these should only be keys, if im right
-                else if(response.every(entry => !Array.isArray(entry))) {
-                    responseObjects = [response[0]];
-                    for(let i = 1; i < response.length; i ++) {
-                        responseObjects.push({
-                            key: response[i],
-                        });
-                    }
+            }
+            //Check for a single dimensional array, these should only be keys, if im right
+            else if(response.every(entry => !Array.isArray(entry))) {
+                responseObjects = [response[0]];
+                for(let i = 1; i < response.length; i++) {
+                    responseObjects.push({
+                        key: response[i],
+                    });
                 }
-                return responseObjects;
+            }
+            return responseObjects;
         }
         else if(Array.isArray(response) && response.length > 1 && this.isOnlyTwoDimensionalArray(response)) {
             return this.handleResponse(this.reduceArrayDimension(response))

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -112,7 +112,7 @@ export class Redisearch extends Module {
             if (parameters.withSortKeys === true)
                 args.push('WITHSORTKEYS')
             if (parameters.filter !== undefined) {
-                for (let item of parameters.filter) {
+                for (const item of parameters.filter) {
                     args = args.concat(['FILTER', item.field, item.min.toString(), item.max.toString()])
                 }
             }

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -123,9 +123,9 @@ export class Redisearch extends Module {
                     parameters.geoFilter.measurement
                 ])
             if(parameters.inKeys !== undefined)
-                args = args.concat(['INKEYS', parameters.inKeys.num.toString(), parameters.inKeys.field])
+                args = args.concat(['INKEYS', parameters.inKeys.num.toString()].concat(parameters.inKeys.field.map(f => f.toString())));
             if(parameters.inFields !== undefined)
-                args = args.concat(['INFIELDS', parameters.inFields.num.toString()].concat(parameters.inFields.field))
+                args = args.concat(['INFIELDS', parameters.inFields.num.toString()].concat(parameters.inFields.field.map(f => f.toString())));
             if(parameters.return !== undefined) {
                 args.push('RETURN');
                 if(parameters.return.num)
@@ -698,11 +698,11 @@ export type FTSearchParameters = {
     },
     inKeys?: {
         num: number,
-        field: string
+        field: (string | number)[],
     },
     inFields?: {
         num: number,
-        field: string[]
+        field: (string | number)[]
     },
     return?: {
         num: number,

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -179,7 +179,6 @@ export class Redisearch extends Module {
             if (parameters.limit !== undefined)
                 args = args.concat(['LIMIT', parameters.limit.first.toString(), parameters.limit.num.toString()])
         }
-        console.log(args);
         const response = await this.sendCommand('FT.SEARCH', args);
         return this.handleResponse(response);
     }

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -180,7 +180,7 @@ export class Redisearch extends Module {
                 args = args.concat(['LIMIT', parameters.limit.first.toString(), parameters.limit.num.toString()])
         }
         const response = await this.sendCommand('FT.SEARCH', args);
-        return this.handleResponse(response);
+        return this.handleResponse(response, true);
     }
 
     /**

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -57,15 +57,15 @@ export class Redisearch extends Module {
                 args = args.concat(['PAYLOAD_FIELD', parameters.payloadField])
             if (parameters.maxTextFields !== undefined)
                 args = args.concat(['MAXTEXTFIELDS', parameters.maxTextFields.toString()])
-            if (parameters.noOffsets !== undefined)
-                args.push('NOOFFSETS');
             if (parameters.temporary !== undefined)
-                args.push('TEMPORARY');
-            if (parameters.nohl !== undefined)
+                args = args.concat(['TEMPORARY', parameters.temporary.toString()]);
+            if (parameters.noOffsets === true)
+                args.push('NOOFFSETS');
+            if (parameters.nohl === true)
                 args.push('NOHL');
-            if (parameters.noFields !== undefined)
+            if (parameters.noFields === true)
                 args.push('NOFIELDS');
-            if (parameters.noFreqs !== undefined)
+            if (parameters.noFreqs === true)
                 args.push('NOFREQS');
             if (parameters.stopwords !== undefined) {
                 args.push('STOPWORDS');
@@ -78,7 +78,7 @@ export class Redisearch extends Module {
         args.push('SCHEMA');
         for (const field of schemaFields) {
             args.push(field.name)
-            if (field.as)
+            if (field.as !== undefined)
                 args = args.concat(['AS', field.as])
             args.push(field.type);
             if (field.nostem === true) args.push('NOSTEM');
@@ -562,270 +562,441 @@ export class Redisearch extends Module {
 
 /**
  * The 'FT.CREATE' additional optional parameters
- * @param filter The expression of the 'FILTER' parameter. is a filter expression with the full RediSearch aggregation expression language.
- * @param payloadField The field of the 'PAYLOAD' parameter. If set indicates the document field that should be used as a binary safe payload string to the document, that can be evaluated at query time by a custom scoring function, or retrieved to the client.
- * @param maxTextFields The 'MAXTEXTFIELDS' parameter. For efficiency, RediSearch encodes indexes differently if they are created with less than 32 text fields.
- * @param noOffsets The 'NOFFSETS' parameter. If set, we do not store term offsets for documents (saves memory, does not allow exact searches or highlighting).
- * @param temporary The 'TEMPORARY' parameter. Create a lightweight temporary index which will expire after the specified period of inactivity.
- * @param nohl The 'NOHL' parameter. Conserves storage space and memory by disabling highlighting support. If set, we do not store corresponding byte offsets for term positions.
- * @param noFields The 'NOFIELDS' parameter. If set, we do not store field bits for each term.
- * @param noFreqs The 'NOFREQS' parameter.  If set, we avoid saving the term frequencies in the index.
- * @param skipInitialScan The 'SKIPINITIALSCAN' parameter. If set, we do not scan and index. 
- * @param prefix The 'PREFIX' parameter. tells the index which keys it should index.
- * @param prefix.count The count argument of the 'PREFIX' parameter. 
- * @param prefix.name The name argument of the 'PREFIX' parameter. 
- * @param language The 'LANGUAGE' parameter.  If set indicates the default language for documents in the index.
- * @param languageField The 'LANGUAGE_FIELD' parameter. If set indicates the document field that should be used as the document language.
- * @param score The 'SCORE' parameter. If set indicates the default score for documents in the index.
- * @param scoreField The 'SCORE_FIELD' parameter. If set indicates the document field that should be used as the document's rank based on the user's ranking. 
- * @param stopwords The 'STOPWORDS' parameter. If set, we set the index with a custom stopword list, to be ignored during indexing and search time.
- * @param stopwords.num The num argument of the 'STOPWORDS' parameter. 
- * @param stopwords.stopword The stopword argument of the 'STOPWORDS' parameter.
- */
-export type FTCreateParameters = {
+*/
+export interface FTCreateParameters {
+    /**
+    * The expression of the 'FILTER' parameter. is a filter expression with the full RediSearch aggregation expression language.
+    */
     filter?: string,
+    /**
+    * The field of the 'PAYLOAD' parameter. If set indicates the document field that should be used as a binary safe payload string to the document, that can be evaluated at query time by a custom scoring function, or retrieved to the client.
+    */
     payloadField?: string,
+    /**
+    * The 'MAXTEXTFIELDS' parameter. For efficiency, RediSearch encodes indexes differently if they are created with less than 32 text fields.
+    */
     maxTextFields?: number,
-    noOffsets?: string,
+    /**
+    * The 'NOFFSETS' parameter. If set, we do not store term offsets for documents (saves memory, does not allow exact searches or highlighting).
+    */
+    noOffsets?: boolean,
+    /**
+    * The 'TEMPORARY' parameter. Create a lightweight temporary index which will expire after the specified period of inactivity.
+    */
     temporary?: number,
-    nohl?: string,
-    noFields?: string,
-    noFreqs?: string,
+    /** 
+    * The 'NOHL' parameter. Conserves storage space and memory by disabling highlighting support. If set, we do not store corresponding byte offsets for term positions.
+    */
+    nohl?: boolean,
+    /**
+    *  The 'NOFIELDS' parameter. If set, we do not store field bits for each term.
+    */
+    noFields?: boolean,
+    /**
+    *  The 'NOFREQS' parameter.  If set, we avoid saving the term frequencies in the index.
+    */
+    noFreqs?: boolean,
+    /**
+    *  The 'SKIPINITIALSCAN' parameter. If set, we do not scan and index. 
+    */
     skipInitialScan?: boolean
+    /**
+    *  The 'PREFIX' parameter. tells the index which keys it should index.
+    */
     prefix?: string[],
+    /**
+    * The 'LANGUAGE' parameter.  If set indicates the default language for documents in the index.
+    */
     language?: string,
+    /**
+    * The 'LANGUAGE_FIELD' parameter. If set indicates the document field that should be used as the document language.
+    */
     languageField?: string,
+    /**
+    * The 'SCORE' parameter. If set indicates the default score for documents in the index. 
+    */
     score?: string,
+    /**
+    * The 'SCORE_FIELD' parameter. If set indicates the document field that should be used as the document's rank based on the user's ranking. 
+    */
     scoreField?: string
+    /**
+    * The 'STOPWORDS' parameter. If set, we set the index with a custom stopword list, to be ignored during indexing and search time. 
+    */
     stopwords?: string[],
 }
 
 /**
  * The field parameter
- * @param sortable The 'SORTABLE' parameter. Numeric, tag or text field can have the optional SORTABLE argument that allows the user to later sort the results by the value of this field (this adds memory overhead so do not declare it on large text fields).
- * @param nostem The 'NOSTEM' parameter. Text fields can have the NOSTEM argument which will disable stemming when indexing its values. This may be ideal for things like proper names.
- * @param noindex The 'NOINDEX' parameter. Fields can have the NOINDEX option, which means they will not be indexed. This is useful in conjunction with SORTABLE , to create fields whose update using PARTIAL will not cause full reindexing of the document. If a field has NOINDEX and doesn't have SORTABLE, it will just be ignored by the index.
- * @param phonetic The 'PHONETIC' parameter. Declaring a text field as PHONETIC will perform phonetic matching on it in searches by default. The obligatory {matcher} argument specifies the phonetic algorithm and language used.
- * @param weight The 'WEIGHT' parameter. For TEXT fields, declares the importance of this field when calculating result accuracy. This is a multiplication factor, and defaults to 1 if not specified.
- * @param seperator The 'SEPERATOR' parameter. For TAG fields, indicates how the text contained in the field is to be split into individual tags. The default is , . The value must be a single character.
- */
-export type FTFieldOptions = {
+*/
+export interface FTFieldOptions {
+    /**
+    * The 'SORTABLE' parameter. Numeric, tag or text field can have the optional SORTABLE argument that allows the user to later sort the results by the value of this field (this adds memory overhead so do not declare it on large text fields).
+    */
     sortable?: boolean,
+    /**
+    *  The 'NOINDEX' parameter. Fields can have the NOINDEX option, which means they will not be indexed. This is useful in conjunction with SORTABLE , to create fields whose update using PARTIAL will not cause full reindexing of the document. If a field has NOINDEX and doesn't have SORTABLE, it will just be ignored by the index.
+    */
     noindex?: boolean,
+    /**
+    * The 'NOSTEM' parameter. Text fields can have the NOSTEM argument which will disable stemming when indexing its values. This may be ideal for things like proper names.
+    */
     nostem?: boolean,
+    /**
+    *  The 'PHONETIC' parameter. Declaring a text field as PHONETIC will perform phonetic matching on it in searches by default. The obligatory {matcher} argument specifies the phonetic algorithm and language used.
+    */
     phonetic?: string,
+    /**
+    * The 'WEIGHT' parameter. For TEXT fields, declares the importance of this field when calculating result accuracy. This is a multiplication factor, and defaults to 1 if not specified.
+    */
     weight?: number,
+    /**
+    * The 'SEPERATOR' parameter. For TAG fields, indicates how the text contained in the field is to be split into individual tags. The default is , . The value must be a single character.
+    */
     seperator?: string
+    /**
+     * The 'UNF' parameter. By default, SORTABLE applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using UNF (un-normalized form) it is possible to disable the normalization and keep the original form of the value. 
+     */
     unf?: boolean,
+    /**
+     * For `TAG` attributes, keeps the original letter cases of the tags. If not specified, the characters are converted to lowercase.
+     */
     caseSensitive?: boolean,
 }
 
 /**
  * The parameters of the 'FT.CREATE' command, schema fields (Field comming after the 'SCHEMA' command)
- * @param name The name of the field
- * @param type The type of the field
- * @param sortable The 'SORTABLE' parameter. Numeric, tag or text field can have the optional SORTABLE argument that allows the user to later sort the results by the value of this field (this adds memory overhead so do not declare it on large text fields).
- * @param nostem The 'NOSTEM' parameter. Text fields can have the NOSTEM argument which will disable stemming when indexing its values. This may be ideal for things like proper names.
- * @param noindex The 'NOINDEX' parameter. Fields can have the NOINDEX option, which means they will not be indexed. This is useful in conjunction with SORTABLE , to create fields whose update using PARTIAL will not cause full reindexing of the document. If a field has NOINDEX and doesn't have SORTABLE, it will just be ignored by the index.
- * @param phonetic The 'PHONETIC' parameter. Declaring a text field as PHONETIC will perform phonetic matching on it in searches by default. The obligatory {matcher} argument specifies the phonetic algorithm and language used.
- * @param weight The 'WEIGHT' parameter. For TEXT fields, declares the importance of this field when calculating result accuracy. This is a multiplication factor, and defaults to 1 if not specified.
- * @param seperator The 'SEPERATOR' parameter. For TAG fields, indicates how the text contained in the field is to be split into individual tags. The default is , . The value must be a single character.
- * @param as The 'AS' parameter. Used when creating an index on 'JSON'.
- */
+*/
 export interface FTSchemaField extends FTFieldOptions {
+    /**
+    * The name of the field
+    */
     name: string,
+    /**
+    * The type of the field
+    */
     type: FTFieldType,
+    /**
+    * The 'AS' parameter. Used when creating an index on 'JSON'.
+    */
     as?: string
 }
 
 /**
  * The parameter of the 'FT.SEARCH' command
- * @param noContent The 'NOTCONTENT' parameter. If it appears after the query, we only return the document ids and not the content.
- * @param verbatim The 'VERBATIM' parameter.  if set, we do not try to use stemming for query expansion but search the query terms verbatim.
- * @param noStopWords The 'noStopWords' parameter. If set, we do not filter stopwords from the query. 
- * @param withScores The 'WITHSCORES' parameter. If set, we also return the relative internal score of each document.
- * @param withPayloads The 'WITHPAYLOADS' parameter. If set, we retrieve optional document payloads (see FT.ADD).
- * @param withSoryKeys The 'WITHSORTKEYS' parameter. Only relevant in conjunction with SORTBY . Returns the value of the sorting key, right after the id and score and /or payload if requested.
- * @param filter The 'FILTER' parameter.  If set, and numeric_field is defined as a numeric field in FT.CREATE, we will limit results to those having numeric values ranging between min and max. min and max follow ZRANGE syntax, and can be -inf , +inf and use ( for exclusive ranges. 
- * @param filter.field The numeric_field argument of the 'FILTER' parameter
- * @param filter.min The min argument of the 'FILTER' parameter
- * @param filter.max The max argument of the 'FILTER' parameter
- * @param geoFilter The 'GEOFILTER' parameter. If set, we filter the results to a given radius from lon and lat. Radius is given as a number and units.
- * @param geoFilter.field The field of the 'GEOFILTER' parameter
- * @param geoFilter.lon The lon argument of the 'GEOFILTER' parameter
- * @param geoFilter.lat The lat argument of the 'GEOFILTER' parameter
- * @param geoFilter.radius The radius argument of the 'GEOFILTER' parameter
- * @param geoFilter.measurement The measurement argument of the 'GEOFILTER' parameter
- * @param inKeys The 'INKEYS' parameter. If set, we limit the result to a given set of keys specified in the list. the first argument must be the length of the list, and greater than zero.
- * @param inKeys.num The num argument of the 'INKEYS' parameter
- * @param inKeys.field The field argument of the 'INKEYS' parameter
- * @param inFields The 'INFIELDS' parameter. If set, filter the results to ones appearing only in specific fields of the document, like title or URL.
- * @param inFields.num The num argument of the 'INFIELDS' parameter
- * @param inFields.field The field argument of the 'INFIELDS' parameter
- * @param return The 'RETURN' parameter. Use this keyword to limit which fields from the document are returned.
- * @param return.num The num argument of the 'RETURN' parameter. If num is 0, it acts like NOCONTENT.
- * @param return.fields The fields of the 'RETURN' parameter. No need to pass if num is 0.
- * @param return.fields.name The name of the field.
- * @param return.fields.as The 'AS' parameter following a "field" name, used by index type "JSON".
- * @param summarize The 'SUMMARIZE' parameter. Use this option to return only the sections of the field which contain the matched text.
- * @param summarize.fields The fields argument of the 'SUMMARIZE' parameter
- * @param summarize.fields.num The num argument of the fields argument. 
- * @param summarize.fields.field The field argument of the fields argument
- * @param summarize.frags The fargs argument of the 'SUMMARIZE' parameter
- * @param summarize.len The len argument of the 'SUMMARIZE' parameter
- * @param summarize.seperator The seperator argument of the 'SUMMARIZE' parameter
- * @param highlight The 'HIGHLIGHT' parameter. Use this option to format occurrences of matched text.
- * @param highlight.fields The fields argument of the 'HIGHLIGHT' parameter
- * @param highlight.fields.num The num argument of the fields argument
- * @param highlight.fields.field The field argument of the fields argument
- * @param highlight.tags The tags argument of the 'HIGHLIGHT' parameter
- * @param highlight.open The open argument of the tags argument
- * @param highlight.close The close argument of the tags argument
- * @param slop The 'SLOP' parameter. If set, we allow a maximum of N intervening number of unmatched offsets between phrase terms.
- * @param inorder The 'INORDER' parameter. If set, and usually used in conjunction with SLOP, we make sure the query terms appear in the same order in the document as in the query, regardless of the offsets between them. 
- * @param language The 'LANGUAGE' parameter. If set, we use a stemmer for the supplied language during search for query expansion.
- * @param expander The 'EXPANDER' parameter. If set, we will use a custom query expander instead of the stemmer.
- * @param scorer The 'SCORER' parameter. If set, we will use a custom scoring function defined by the user.
- * @param explainScore The 'EXPLAINSCORE' parameter. If set, will return a textual description of how the scores were calculated.
- * @param payload The 'PAYLOAD' parameter. Add an arbitrary, binary safe payload that will be exposed to custom scoring functions.
- * @param sortBy The 'SORTBY' parameter. If specified, the results are ordered by the value of this field. This applies to both text and numeric fields.
- * @param sortBy.field The <> argument of the 'SORTBY' parameter
- * @param sortBy.sort The <> argument of the 'SORTBY' parameter
- * @param limit The 'LIMIT' parameter. If the parameters appear after the query, we limit the results to the offset and number of results given.
- * @param limit.first The <> argument of the 'LIMIT' parameter
- * @param limit.num The <> argument of the 'LIMIT' parameter
  */
-export type FTSearchParameters = {
+export interface FTSearchParameters {
+    /**
+    * The 'NOTCONTENT' parameter. If it appears after the query, we only return the document ids and not the content.
+    */
     noContent?: boolean,
+    /**
+    * The 'VERBATIM' parameter. if set, we do not try to use stemming for query expansion but search the query terms verbatim.
+    */
     verbatim?: boolean,
+    /**
+     * The 'noStopWords' parameter. If set, we do not filter stopwords from the query. 
+     */
     noStopWords?: boolean,
+    /**
+     * The 'WITHSCORES' parameter. If set, we also return the relative internal score of each document.
+     */
     withScores?: boolean,
+    /**
+     * The 'WITHPAYLOADS' parameter. If set, we retrieve optional document payloads (see FT.ADD).
+    */
     withPayloads?: boolean,
+    /**
+     * The 'WITHSORTKEYS' parameter. Only relevant in conjunction with SORTBY . Returns the value of the sorting key, right after the id and score and /or payload if requested.
+     */
     withSortKeys?: boolean,
+    /**
+     * The 'FILTER' parameter.  If set, and numeric_field is defined as a numeric field in FT.CREATE, we will limit results to those having numeric values ranging between min and max. min and max follow ZRANGE syntax, and can be -inf , +inf and use ( for exclusive ranges. 
+     */
     filter?: {
+        /**
+         * The numeric_field argument of the 'FILTER' parameter
+         */
         field: string,
+        /**
+         * The min argument of the 'FILTER' parameter
+         */
         min: number,
+        /**
+         * The max argument of the 'FILTER' parameter
+         */
         max: number
     }[],
+    /**
+     * The 'GEOFILTER' parameter. If set, we filter the results to a given radius from lon and lat. Radius is given as a number and units.
+     */
     geoFilter?: {
+        /**
+         * The field of the 'GEOFILTER' parameter
+         */
         field: string,
+        /**
+         * The lon argument of the 'GEOFILTER' parameter
+         */
         lon: number,
+        /**
+         * The lat argument of the 'GEOFILTER' parameter
+         */
         lat: number,
+        /**
+         * The radius argument of the 'GEOFILTER' parameter
+         */
         radius: number,
+        /**
+         * The measurement argument of the 'GEOFILTER' parameter
+         */
         measurement: 'm' | 'km' | 'mi' | 'ft'
     },
+    /**
+     * The 'INKEYS' parameter. If set, we limit the result to a given set of keys specified in the list. the first argument must be the length of the list, and greater than zero.
+     */
     inKeys?: (string | number)[],
+    /**
+     * The 'INFIELDS' parameter. If set, filter the results to ones appearing only in specific fields of the document, like title or URL.
+     */
     inFields?: (string | number)[],
+    /**
+     *  The 'RETURN' parameter. Use this keyword to limit which fields from the document are returned.
+     */
     return?: (string | {
+        /**
+         * The name of the field.
+         */
         field: string,
+        /** 
+         * The 'AS' parameter following a "field" name, used by index type "JSON".
+        */
         as?: string,
-    })[] ,
+    })[],
+    /**
+     * The 'SUMMARIZE' parameter. Use this option to return only the sections of the field which contain the matched text. 
+     */
     summarize?: {
+        /**
+         * The fields argument of the 'SUMMARIZE' parameter
+         */
         fields?: string[],
+        /**
+         * The fargs argument of the 'SUMMARIZE' parameter
+         */
         frags?: number,
+        /**
+         * The len argument of the 'SUMMARIZE' parameter
+         */
         len?: number,
+        /**
+         * The seperator argument of the 'SUMMARIZE' parameter
+         */
         seperator?: string
     },
+    /**
+     * The 'HIGHLIGHT' parameter. Use this option to format occurrences of matched text.
+     */
     highlight?: {
+        /**
+         * The fields argument of the 'HIGHLIGHT' parameter
+         */
         fields?: string[],
+        /**
+         * The tags argument of the 'HIGHLIGHT' parameter
+         */
         tags?: {
+            /**
+             * The open argument of the tags argument
+             */
             open: string,
+            /**
+             * The close argument of the tags argument
+             */
             close: string
         },
     },
+    /**
+     * The 'SLOP' parameter. If set, we allow a maximum of N intervening number of unmatched offsets between phrase terms.
+     */
     slop?: number,
+    /**
+     * The 'INORDER' parameter. If set, and usually used in conjunction with SLOP, we make sure the query terms appear in the same order in the document as in the query, regardless of the offsets between them. 
+     */
     inOrder?: boolean,
+    /**
+     * The 'LANGUAGE' parameter. If set, we use a stemmer for the supplied language during search for query expansion.
+     */
     language?: string,
+    /**
+     * The 'EXPANDER' parameter. If set, we will use a custom query expander instead of the stemmer.
+     */
     expander?: string,
+    /**
+     * The 'SCORER' parameter. If set, we will use a custom scoring function defined by the user.
+     */
     scorer?: string,
+    /**
+     * The 'EXPLAINSCORE' parameter. If set, will return a textual description of how the scores were calculated.
+     */
     explainScore?: boolean,
+    /**
+     * The 'PAYLOAD' parameter. Add an arbitrary, binary safe payload that will be exposed to custom scoring functions.
+     */
     payload?: string,
+    /**
+     * The 'SORTBY' parameter. If specified, the results are ordered by the value of this field. This applies to both text and numeric fields.
+     */
     sortBy?: {
+        /**
+         * The field argument of the 'SORTBY' parameter
+         */
         field: string,
+        /**
+         * The sort argument of the 'SORTBY' parameter
+         */
         sort: FTSort
     },
+    /**
+     * The 'LIMIT' parameter. If the parameters appear after the query, we limit the results to the offset and number of results given.
+     */
     limit?: {
+        /**
+         * The first argument of the 'LIMIT' parameter
+         */
         first: number,
+        /**
+        * The num argument of the 'LIMIT' parameter
+        */
         num: number
     }
 }
 
 /**
  * The additional parameter of 'FT.AGGREGATE' command
- * @param load The 'LOAD' parameter. 
- * @param load.nargs The number of arguments
- * @param load.property The property name
- * @param apply Create new fields using 'APPLY' keyword for aggregations
- * @param groupby The 'GROUPBY' parameter.
- * @param groupby.nargs The number of arguments of the 'GROUPBY' parameter
- * @param groupby.properties The property name of the 'GROUPBY' parameter
- * @param reduce The 'REDUCE' parameter.
- * @param sortby The 'SORTBY' parameter. 
- * @param sortby.nargs The number of arguments of the 'SORTBY' parameter
- * @param sortby.properties A list of property names of the 'SORTBY' parameter
- * @param sortby.sort The sort type of the 'SORTBY' parameter
- * @param sortby.max The max of the 'SORTBY' parameter
- * @param expression Given expressions starting by the 'APPLY' keyword
- * @param limit The 'LIMIT' parameter.
- * @param limit.offset The offset of the 'LIMIT' parameter
- * @param limit.numberOfResults The number of results of the 'LIMIT' parameter
- * @param filter The expression of the 'FILTER' parameter.
  */
 export type FTAggregateParameters = {
+    /**
+     * The 'LOAD' parameter. 
+     */
     load?: {
+        /**
+         * The number of arguments
+         */
         nargs: string,
+        /**
+         * The property name
+         */
         properties: string[]
     },
+    /**
+     *  Create new fields using 'APPLY' keyword for aggregations
+     */
     apply?: FTExpression[],
+    /**
+     * The 'GROUPBY' parameter.
+     */
     groupby?: {
+        /**
+         * The number of arguments of the 'GROUPBY' parameter
+         */
         nargs: string,
+        /**
+         * The property name of the 'GROUPBY' parameter
+         */
         properties: string[]
     },
+    /**
+     * The 'REDUCE' parameter.
+     */
     reduce?: FTReduce[],
+    /**
+     * The 'SORTBY' parameter. 
+     */
     sortby?: {
+        /**
+         *  The number of arguments of the 'SORTBY' parameter
+         */
         nargs: string,
+        /**
+         * A list of property names of the 'SORTBY' parameter
+         */
         properties: FTSortByProperty[],
+        /**
+         * The sort type of the 'SORTBY' parameter
+         */
         max: number
     },
+    /**
+     *  Given expressions starting by the 'APPLY' keyword
+     */
     expressions?: FTExpression[],
+    /**
+     * The 'LIMIT' parameter.
+     */
     limit?: {
+        /**
+         * The offset of the 'LIMIT' parameter
+         */
         offset: string,
+        /**
+         * The number of results of the 'LIMIT' parameter
+         */
         numberOfResults: number
     },
+    /**
+     * The expression of the 'FILTER' parameter.
+     */
     filter?: string
 }
 
 /**
  * The expressions given to the 'APPLY' key word
- * @param expression The expression given
- * @param as The value of 'AS' of the expression determining the name of it.
  */
-export type FTExpression = {
+export interface FTExpression {
+    /**
+     * The expression given
+     */
     expression: string,
+    /**
+     * The value of 'AS' of the expression determining the name of it.
+     */
     as: string
 }
 
 /**
  * The 'REDUCE' parameter.
- * @param function A function of the 'REDUCE' parameter
- * @param nargs The number of arguments of the 'REDUCE' parameter
- * @param arg The argument of the 'REDUCE' parameter
- * @param as The name of the function of the 'REDUCE' parameter
  */
-export type FTReduce = {
+export interface FTReduce {
+    /**
+     * A function of the 'REDUCE' parameter
+     */
     function: string,
+    /**
+     * The number of arguments of the 'REDUCE' parameter
+     */
     nargs: string,
+    /**
+     * The argument of the 'REDUCE' parameter
+     */
     args: string[],
+    /**
+     * The name of the function of the 'REDUCE' parameter
+     */
     as?: string
 }
 
 /**
  * The 'SORT BY' property object
- * @param property The value of the property
- * @param sort The 'SORT' value of the property
  */
-export type FTSortByProperty = {
+export interface FTSortByProperty {
+    /**
+     * The value of the property
+     */
     property: string,
+    /**
+     * The 'SORT' value of the property
+     */
     sort: FTSort
 }
 
@@ -838,40 +1009,60 @@ export type FTSort = 'ASC' | 'DESC';
 
 /**
  * The additional parameters of 'FT.SUGADD' command
- * @param incr The 'INCR' parameter. if set, we increment the existing entry of the suggestion by the given score, instead of replacing the score. This is useful for updating the dictionary based on user queries in real time
- * @param payload The 'PAYLOAD' parameter. If set, we save an extra payload with the suggestion, that can be fetched by adding the WITHPAYLOADS argument to FT.SUGGET
  */
-export type FTSugAddParameters = {
+export interface FTSugAddParameters {
+    /**
+     * The 'INCR' parameter. if set, we increment the existing entry of the suggestion by the given score, instead of replacing the score. This is useful for updating the dictionary based on user queries in real time
+     */
     incr: boolean,
+    /**
+     * The 'PAYLOAD' parameter. If set, we save an extra payload with the suggestion, that can be fetched by adding the WITHPAYLOADS argument to FT.SUGGET
+     */
     payload: string
 }
 
 /**
  * The additional parameters of 'FT.SUGGET' command
- * @param fuzzy The 'FUZZY' parameter. if set, we do a fuzzy prefix search, including prefixes at Levenshtein distance of 1 from the prefix sent
- * @param max The 'MAX' parameter. If set, we limit the results to a maximum of num (default: 5).
- * @param withScores The 'WITHSCORES' parameter. If set, we also return the score of each suggestion. this can be used to merge results from multiple instances
- * @param withPayloads The 'WITHPAYLOADS' parameter. If set, we return optional payloads saved along with the suggestions. If no payload is present for an entry, we return a Null Reply.
  */
-export type FTSugGetParameters = {
+export interface FTSugGetParameters {
+    /**
+     * The 'FUZZY' parameter. if set, we do a fuzzy prefix search, including prefixes at Levenshtein distance of 1 from the prefix sent
+     */
     fuzzy: boolean,
+    /**
+     * The 'MAX' parameter. If set, we limit the results to a maximum of num (default: 5).
+     */
     max: number,
+    /**
+     * The 'WITHSCORES' parameter. If set, we also return the score of each suggestion. this can be used to merge results from multiple instances
+     */
     withScores: boolean,
+    /**
+     * The 'WITHPAYLOADS' parameter. If set, we return optional payloads saved along with the suggestions. If no payload is present for an entry, we return a Null Reply.
+     */
     withPayloads: boolean
 }
 
 /**
  * The additional parameters of 'FT.SPELLCHECK' command
- * @param terms A list of terms
- * @param terms.type The type of the term
- * @param terms.dict The dict of the term
- * @param distance The maximal Levenshtein distance for spelling suggestions (default: 1, max: 4)
  */
 export type FTSpellCheck = {
+    /**
+     * A list of terms
+     */
     terms?: {
+        /**
+         * The type of the term
+         */
         type: 'INCLUDE' | 'EXCLUDE',
+        /**
+         * The dict of the term
+         */
         dict?: string
     }[],
+    /**
+     * The maximal Levenshtein distance for spelling suggestions (default: 1, max: 4)
+     */
     distance?: number | string,
 }
 
@@ -893,7 +1084,7 @@ export type FTIndexType = 'HASH' | 'JSON';
 /**
  * The config response
  */
-export type FTConfig = {
+export interface FTConfig {
     EXTLOAD?: string | null,
     SAFEMODE?: string,
     CONCURRENT_WRITE_MODE?: string,
@@ -926,7 +1117,7 @@ export type FTConfig = {
 /**
  * The info response
  */
-export type FTInfo = {
+export interface FTInfo {
     index_name?: string,
     index_options?: string[],
     index_definition?: {

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -40,8 +40,8 @@ export class Redisearch extends Module {
         if (parameters !== undefined) {
             if (parameters.prefix !== undefined) {
                 args.push('PREFIX');
-                for (const prefix of parameters.prefix)
-                    args = args.concat([prefix.count.toString(), prefix.name])
+                args.push(parameters.prefix.length.toString());
+                args = args.concat(parameters.prefix);
             }
             if (parameters.filter !== undefined)
                 args = args.concat(['FILTER', parameters.filter])
@@ -562,10 +562,7 @@ export type FTCreateParameters = {
     noFields?: string,
     noFreqs?: string,
     skipInitialScan?: boolean
-    prefix?: {
-        count: number,
-        name: string
-    }[],
+    prefix?: string[],
     language?: string,
     languageField?: string,
     score?: string,

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -72,7 +72,7 @@ export class Redisearch extends Module {
                 args.push(`${parameters.stopwords.length}`)
                 args = args.concat(parameters.stopwords)
             }
-            if(parameters.skipInitialScan !== undefined)
+            if(parameters.skipInitialScan === true)
                 args.push('SKIPINITIALSCAN')
         }
         args.push('SCHEMA');
@@ -136,14 +136,15 @@ export class Redisearch extends Module {
                 args = args.concat(['INFIELDS', `${parameters.inFields.length}`].concat(parameters.inFields.map(inFieldItem => `${inFieldItem}`)))
             if(parameters.return !== undefined) {
                 args.push('RETURN')
-                //Else we need to expand the objects
                 let itemCount = 0
                 let tempList = []
                 for (const returnItem of parameters.return) {
                     if(typeof returnItem === "string") {
+                        //Strings can be pushed directly
                         tempList.push(returnItem)
                         itemCount++
                     } else {
+                        //Objects need to be converted to strings
                         tempList.push(returnItem.field)
                         itemCount++
                         if(returnItem.as !== undefined) {

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -112,7 +112,7 @@ export class Redisearch extends Module {
             if(parameters.withSortKeys === true)
                 args.push('WITHSORTKEYS')
             if(parameters.filter !== undefined)
-            args = args.concat(['FILTER', parameters.filter.field, parameters.filter.min.toString(), parameters.filter.max.toString()])
+                args = args.concat(['FILTER', parameters.filter.field, parameters.filter.min.toString(), parameters.filter.max.toString()])
             if(parameters.geoFilter !== undefined)
                 args = args.concat([
                     'GEOFILTER',
@@ -123,9 +123,9 @@ export class Redisearch extends Module {
                     parameters.geoFilter.measurement
                 ])
             if(parameters.inKeys !== undefined)
-                args = args.concat(['INKEYS', parameters.inKeys.num.toString()].concat(parameters.inKeys.field.map(f => f.toString())));
+                args = args.concat(['INKEYS', parameters.inKeys.length.toString()].concat(parameters.inKeys.map(f => f.toString())));
             if(parameters.inFields !== undefined)
-                args = args.concat(['INFIELDS', parameters.inFields.num.toString()].concat(parameters.inFields.field.map(f => f.toString())));
+                args = args.concat(['INFIELDS', parameters.inFields.length.toString()].concat(parameters.inFields.map(f => f.toString())));
             if(parameters.return !== undefined) {
                 args.push('RETURN');
                 if(parameters.return.num)
@@ -696,14 +696,8 @@ export type FTSearchParameters = {
         radius: number,
         measurement: 'm' | 'km' | 'mi' | 'ft'
     },
-    inKeys?: {
-        num: number,
-        field: (string | number)[],
-    },
-    inFields?: {
-        num: number,
-        field: (string | number)[]
-    },
+    inKeys?: (string | number)[],
+    inFields?: (string | number)[],
     return?: {
         num: number,
         fields?: {

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -37,53 +37,53 @@ export class Redisearch extends Module {
      */
     async create(index: string, indexType: FTIndexType, schemaFields: FTSchemaField[], parameters?: FTCreateParameters): Promise<'OK' | string> {
         let args: string[] = [index, 'ON', indexType]
-        if(parameters !== undefined) {
-            if(parameters.prefix !== undefined) {
+        if (parameters !== undefined) {
+            if (parameters.prefix !== undefined) {
                 args.push('PREFIX');
-                for(const prefix of parameters.prefix)
+                for (const prefix of parameters.prefix)
                     args = args.concat([prefix.count.toString(), prefix.name])
             }
-            if(parameters.filter !== undefined)
+            if (parameters.filter !== undefined)
                 args = args.concat(['FILTER', parameters.filter])
-            if(parameters.language !== undefined)
+            if (parameters.language !== undefined)
                 args = args.concat(['LANGUAGE', parameters.language]);
-            if(parameters.languageField !== undefined)
+            if (parameters.languageField !== undefined)
                 args = args.concat(['LANGUAGE_FIELD', parameters.languageField]);
-            if(parameters.score !== undefined)
+            if (parameters.score !== undefined)
                 args = args.concat(['SCORE', parameters.score])
-            if(parameters.scoreField !== undefined)
+            if (parameters.scoreField !== undefined)
                 args = args.concat(['SCORE_FIELD', parameters.scoreField])
-            if(parameters.payloadField !== undefined)
+            if (parameters.payloadField !== undefined)
                 args = args.concat(['PAYLOAD_FIELD', parameters.payloadField])
-            if(parameters.maxTextFields !== undefined)
+            if (parameters.maxTextFields !== undefined)
                 args = args.concat(['MAXTEXTFIELDS', parameters.maxTextFields.toString()])
-            if(parameters.noOffsets !== undefined)
+            if (parameters.noOffsets !== undefined)
                 args.push('NOOFFSETS');
-            if(parameters.temporary !== undefined)
+            if (parameters.temporary !== undefined)
                 args.push('TEMPORARY');
-            if(parameters.nohl !== undefined)
+            if (parameters.nohl !== undefined)
                 args.push('NOHL');
-            if(parameters.noFields !== undefined)
+            if (parameters.noFields !== undefined)
                 args.push('NOFIELDS');
-            if(parameters.noFreqs !== undefined)
+            if (parameters.noFreqs !== undefined)
                 args.push('NOFREQS');
-            if(parameters.stopwords !== undefined)
+            if (parameters.stopwords !== undefined)
                 args = args.concat(['STOPWORDS', parameters.stopwords.num.toString(), parameters.stopwords.stopword]);
-            if(parameters.skipInitialScan !== undefined)
+            if (parameters.skipInitialScan !== undefined)
                 args.push('SKIPINITIALSCAN');
         }
         args.push('SCHEMA');
-        for(const field of schemaFields) {
+        for (const field of schemaFields) {
             args.push(field.name)
-            if(field.as)
+            if (field.as)
                 args = args.concat(['AS', field.as])
             args.push(field.type);
-            if(field.nostem !== undefined) args.push('NOSTEM');
-            if(field.weight !== undefined) args = args.concat(['WEIGHT', field.weight.toString()]);
-            if(field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic]);
-            if(field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator]);
-            if(field.sortable !== undefined) args.push('SORTABLE');
-            if(field.noindex !== undefined) args.push('NOINDEX');
+            if (field.nostem !== undefined) args.push('NOSTEM');
+            if (field.weight !== undefined) args = args.concat(['WEIGHT', field.weight.toString()]);
+            if (field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic]);
+            if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator]);
+            if (field.sortable !== undefined) args.push('SORTABLE');
+            if (field.noindex !== undefined) args.push('NOINDEX');
         }
         const response = await this.sendCommand('FT.CREATE', args);
         return this.handleResponse(response);
@@ -98,22 +98,25 @@ export class Redisearch extends Module {
      */
     async search(index: string, query: string, parameters?: FTSearchParameters): Promise<[number, ...Array<string | string[]>]> {
         let args: string[] = [index, query];
-        if(parameters !== undefined) {
-            if(parameters.noContent === true)
+        if (parameters !== undefined) {
+            if (parameters.noContent === true)
                 args.push('NOCONTENT')
-            if(parameters.verbatim === true)
+            if (parameters.verbatim === true)
                 args.push('VERBARIM')
-            if(parameters.noStopWords === true)
+            if (parameters.noStopWords === true)
                 args.push('NOSTOPWORDS')
-            if(parameters.withScores === true)
+            if (parameters.withScores === true)
                 args.push('WITHSCORES')
-            if(parameters.withPayloads === true)
+            if (parameters.withPayloads === true)
                 args.push('WITHPAYLOADS')
-            if(parameters.withSortKeys === true)
+            if (parameters.withSortKeys === true)
                 args.push('WITHSORTKEYS')
-            if(parameters.filter !== undefined)
-                args = args.concat(['FILTER', parameters.filter.field, parameters.filter.min.toString(), parameters.filter.max.toString()])
-            if(parameters.geoFilter !== undefined)
+            if (parameters.filter !== undefined) {
+                for (let item of parameters.filter) {
+                    args = args.concat(['FILTER', item.field, item.min.toString(), item.max.toString()])
+                }
+            }
+            if (parameters.geoFilter !== undefined)
                 args = args.concat([
                     'GEOFILTER',
                     parameters.geoFilter.field,
@@ -122,68 +125,62 @@ export class Redisearch extends Module {
                     parameters.geoFilter.radius.toString(),
                     parameters.geoFilter.measurement
                 ])
-            if(parameters.inKeys !== undefined)
-                args = args.concat(['INKEYS', parameters.inKeys.length.toString()].concat(parameters.inKeys.map(f => f.toString())));
-            if(parameters.inFields !== undefined)
-                args = args.concat(['INFIELDS', parameters.inFields.length.toString()].concat(parameters.inFields.map(f => f.toString())));
-            if(parameters.return !== undefined) {
-                args.push('RETURN');
-                if(parameters.return.num)
-                    args.push(parameters.return.num.toString());
-                if(parameters.return.fields)    
-                    parameters.return.fields.forEach(field => {
-                        args.push(field.name)
-                        if(field.as)
-                            args = args.concat(['AS', field.as])
-                    })
+            if (parameters.inKeys !== undefined)
+                args = args.concat(['INKEYS', parameters.inKeys.length.toString()].concat(parameters.inKeys.map(f => f.toString())))
+            if (parameters.inFields !== undefined)
+                args = args.concat(['INFIELDS', parameters.inFields.length.toString()].concat(parameters.inFields.map(f => f.toString())))
+            if (parameters.return !== undefined) {
+                args.push('RETURN')
+                args.push(parameters.return.length.toString())
+                args = args.concat(parameters.return)
             }
-            if(parameters.summarize !== undefined) {
+            if (parameters.summarize !== undefined) {
                 args.push('SUMMARIZE')
-                if(parameters.summarize.fields !== undefined) {
+                if (parameters.summarize.fields !== undefined) {
                     args.push('FIELDS')
-                    for(const field of parameters.summarize.fields) {
+                    for (const field of parameters.summarize.fields) {
                         args = args.concat([field.num.toString(), field.field]);
                     }
                 }
-                if(parameters.summarize.frags !== undefined) 
+                if (parameters.summarize.frags !== undefined)
                     args = args.concat(['FRAGS', parameters.summarize.frags.toString()])
-                if(parameters.summarize.len !== undefined) 
+                if (parameters.summarize.len !== undefined)
                     args = args.concat(['LEN', parameters.summarize.len.toString()])
-                if(parameters.summarize.seperator !== undefined) 
+                if (parameters.summarize.seperator !== undefined)
                     args = args.concat(['SEPARATOR', parameters.summarize.seperator])
             }
-            if(parameters.highlight !== undefined) {
+            if (parameters.highlight !== undefined) {
                 args.push('HIGHLIGHT')
-                if(parameters.highlight.fields !== undefined) {
+                if (parameters.highlight.fields !== undefined) {
                     args.push('FIELDS')
-                    for(const field of parameters.highlight.fields) {
+                    for (const field of parameters.highlight.fields) {
                         args = args.concat([field.num.toString(), field.field]);
                     }
                 }
-                if(parameters.highlight.tags !== undefined) {
+                if (parameters.highlight.tags !== undefined) {
                     args.push('TAGS')
-                    for(const tag of parameters.highlight.tags) {
+                    for (const tag of parameters.highlight.tags) {
                         args = args.concat([tag.open, tag.close]);
                     }
                 }
             }
-            if(parameters.slop !== undefined)
+            if (parameters.slop !== undefined)
                 args = args.concat(['SLOP', parameters.slop.toString()])
-            if(parameters.inOrder !== undefined)
+            if (parameters.inOrder !== undefined)
                 args.push('INORDER')
-            if(parameters.language !== undefined)
+            if (parameters.language !== undefined)
                 args = args.concat(['LANGUAGE', parameters.language])
-            if(parameters.expander !== undefined)
+            if (parameters.expander !== undefined)
                 args = args.concat(['EXPANDER', parameters.expander])
-            if(parameters.scorer !== undefined)
+            if (parameters.scorer !== undefined)
                 args = args.concat(['SCORER', parameters.scorer])
-            if(parameters.explainScore !== undefined)
+            if (parameters.explainScore !== undefined)
                 args.push('EXPLAINSCORE')
-            if(parameters.payload)
+            if (parameters.payload)
                 args = args.concat(['PAYLOAD', parameters.payload])
-            if(parameters.sortBy !== undefined)
+            if (parameters.sortBy !== undefined)
                 args = args.concat(['SORTBY', parameters.sortBy.field, parameters.sortBy.sort])
-            if(parameters.limit !== undefined)
+            if (parameters.limit !== undefined)
                 args = args.concat(['LIMIT', parameters.limit.first.toString(), parameters.limit.num.toString()])
         }
         console.log(args);
@@ -200,74 +197,74 @@ export class Redisearch extends Module {
      */
     async aggregate(index: string, query: string, parameters?: FTAggregateParameters): Promise<[number, ...Array<string[]>]> {
         let args: string[] = [index, query];
-        if(parameters !== undefined) {
-            if(parameters.load !== undefined) {
+        if (parameters !== undefined) {
+            if (parameters.load !== undefined) {
                 args.push('LOAD')
-                if(parameters.load.nargs !== undefined)
+                if (parameters.load.nargs !== undefined)
                     args.push(parameters.load.nargs);
-                if(parameters.load.properties !== undefined)
+                if (parameters.load.properties !== undefined)
                     parameters.load.properties.forEach(property => {
                         args.push(property);
                     })
             }
-            if(parameters.apply !== undefined) {
+            if (parameters.apply !== undefined) {
                 parameters.apply.forEach(apply => {
                     args.push('APPLY');
                     args.push(apply.expression);
-                    if(apply.as)
+                    if (apply.as)
                         args = args.concat(['AS', apply.as]);
                 })
             }
-            if(parameters.groupby !== undefined){
+            if (parameters.groupby !== undefined) {
                 args.push('GROUPBY')
-                if(parameters.groupby.nargs !== undefined)
+                if (parameters.groupby.nargs !== undefined)
                     args.push(parameters.groupby.nargs);
-                if(parameters.groupby.properties !== undefined) {
+                if (parameters.groupby.properties !== undefined) {
                     parameters.groupby.properties.forEach((property) => {
                         args.push(property);
                     })
                 }
             }
-            if(parameters.reduce !== undefined) {
+            if (parameters.reduce !== undefined) {
                 parameters.reduce.forEach(reduce => {
                     args.push('REDUCE')
-                    if(reduce.function !== undefined)
+                    if (reduce.function !== undefined)
                         args.push(reduce.function);
-                    if(reduce.nargs !== undefined)
+                    if (reduce.nargs !== undefined)
                         args.push(reduce.nargs);
-                    if(reduce.args)
+                    if (reduce.args)
                         reduce.args.forEach(arg => {
                             args.push(arg);
                         })
-                    if(reduce.as !== undefined)
+                    if (reduce.as !== undefined)
                         args = args.concat(['AS', reduce.as]);
                 })
             }
-            if(parameters.sortby !== undefined) {
+            if (parameters.sortby !== undefined) {
                 args.push('SORTBY')
-                if(parameters.sortby.nargs !== undefined)
+                if (parameters.sortby.nargs !== undefined)
                     args.push(parameters.sortby.nargs);
-                if(parameters.sortby.properties)
+                if (parameters.sortby.properties)
                     parameters.sortby.properties.forEach(property => {
                         args.push(property.property);
                         args.push(property.sort);
                     })
-                if(parameters.sortby.max !== undefined)
+                if (parameters.sortby.max !== undefined)
                     args = args.concat(['MAX', parameters.sortby.max.toString()]);
             }
-            if(parameters.expressions !== undefined) {
+            if (parameters.expressions !== undefined) {
                 parameters.expressions.forEach(expression => {
                     args.push('APPLY');
                     args.push(expression.expression);
-                    if(expression.as)
+                    if (expression.as)
                         args = args.concat(['AS', expression.as]);
                 })
             }
-            if(parameters.limit !== undefined) {
+            if (parameters.limit !== undefined) {
                 args.push('LIMIT')
-                if(parameters.limit.offset !== undefined)
+                if (parameters.limit.offset !== undefined)
                     args.push(parameters.limit.offset)
-                if(parameters.limit.numberOfResults !== undefined)
+                if (parameters.limit.numberOfResults !== undefined)
                     args.push(parameters.limit.numberOfResults.toString());
             }
         }
@@ -307,13 +304,13 @@ export class Redisearch extends Module {
      */
     async alter(index: string, field: string, fieldType: FTFieldType, options?: FTFieldOptions): Promise<'OK' | string> {
         let args = [index, 'SCHEMA', 'ADD', field, fieldType]
-        if(options !== undefined) {
-            if(options.sortable !== undefined) args.push('SORTABLE');
-            if(options.noindex !== undefined) args.push('NOINDEX');
-            if(options.nostem !== undefined) args.push('NOSTEM');
-            if(options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic]);
-            if(options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator]);
-            if(options.weight !== undefined) args = args.concat(['WEIGHT', options.weight.toString()]);
+        if (options !== undefined) {
+            if (options.sortable !== undefined) args.push('SORTABLE');
+            if (options.noindex !== undefined) args.push('NOINDEX');
+            if (options.nostem !== undefined) args.push('NOSTEM');
+            if (options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic]);
+            if (options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator]);
+            if (options.weight !== undefined) args = args.concat(['WEIGHT', options.weight.toString()]);
         }
         const response = await this.sendCommand('FT.ALTER', args);
         return this.handleResponse(response);
@@ -327,11 +324,11 @@ export class Redisearch extends Module {
      */
     async dropindex(index: string, deleteHash = false): Promise<'OK' | string> {
         const args = [index];
-        if(deleteHash === true) args.push('DD')
+        if (deleteHash === true) args.push('DD')
         const response = await this.sendCommand('FT.DROPINDEX', args);
         return this.handleResponse(response);
     }
-    
+
     /**
      * Adding alias fron an index
      * @param name The alias name
@@ -363,7 +360,7 @@ export class Redisearch extends Module {
         const response = await this.sendCommand('FT.ALIASDEL', [name]);
         return this.handleResponse(response);
     }
-    
+
     /**
      * Retrieving the distinct tags indexed in a Tag field
      * @param index The index
@@ -383,11 +380,11 @@ export class Redisearch extends Module {
      * @param options The additional optional parameters
      * @returns The current size of the suggestion dictionary
      */
-    async sugadd(key: string, suggestion: string, score: number, options?: FTSugAddParameters): Promise<number>{
+    async sugadd(key: string, suggestion: string, score: number, options?: FTSugAddParameters): Promise<number> {
         let args = [key, suggestion, score];
-        if(options !== undefined && options.incr !== undefined)
+        if (options !== undefined && options.incr !== undefined)
             args.push('INCR');
-        if(options !== undefined && options.payload !== undefined)
+        if (options !== undefined && options.payload !== undefined)
             args = args.concat(['PAYLOAD', options.payload]);
         const response = await this.sendCommand('FT.SUGADD', args);
         return this.handleResponse(response);
@@ -402,13 +399,13 @@ export class Redisearch extends Module {
      */
     async sugget(key: string, prefix: string, options?: FTSugGetParameters): Promise<string> {
         let args = [key, prefix];
-        if(options !== undefined && options.fuzzy !== undefined)
+        if (options !== undefined && options.fuzzy !== undefined)
             args.push('FUZZY');
-        if(options !== undefined && options.max !== undefined)   
+        if (options !== undefined && options.max !== undefined)
             args = args.concat(['MAX', options.max.toString()]);
-        if(options !== undefined && options.withScores !== undefined)
+        if (options !== undefined && options.withScores !== undefined)
             args.push('WITHSCORES');
-        if(options !== undefined && options.withPayloads !== undefined)
+        if (options !== undefined && options.withPayloads !== undefined)
             args.push('WITHPAYLOADS');
         const response = await this.sendCommand('FT.SUGGET', args);
         return this.handleResponse(response);
@@ -443,7 +440,7 @@ export class Redisearch extends Module {
      */
     async synupdate(index: string, groupId: number, terms: string[], skipInitialScan = false): Promise<'OK'> {
         const args = [index, groupId].concat(terms);
-        if(skipInitialScan === true)
+        if (skipInitialScan === true)
             args.push('SKIPINITIALSCAN');
         const response = await this.sendCommand('FT.SYNUPDATE', args);
         return this.handleResponse(response);
@@ -454,7 +451,7 @@ export class Redisearch extends Module {
      * @param index The index
      * @returns A list of synonym terms and their synonym group ids.  
      */
-    async syndump(index: string): Promise<{[key: string]: string | number}> {
+    async syndump(index: string): Promise<{ [key: string]: string | number }> {
         const response = await this.sendCommand('FT.SYNDUMP', [index]);
         return this.handleResponse(response);
     }
@@ -466,20 +463,20 @@ export class Redisearch extends Module {
      * @param options The additional optional parameters
      * @returns An array, in which each element represents a misspelled term from the query
      */
-    async spellcheck(index: string, query: string, options?: FTSpellCheck): Promise<string[]>  {
+    async spellcheck(index: string, query: string, options?: FTSpellCheck): Promise<string[]> {
         let args = [index, query];
-        if(options !== undefined && options.distance !== undefined)
+        if (options !== undefined && options.distance !== undefined)
             args = args.concat(['DISTANCE', options.distance])
-        if(options !== undefined && options.terms !== undefined) {
+        if (options !== undefined && options.terms !== undefined) {
             args.push('TERMS');
-            for(const term of options.terms) {
+            for (const term of options.terms) {
                 args = args.concat([term.type, term.dict]);
             }
         }
         const response = await this.sendCommand('FT.SPELLCHECK', args);
         return this.handleResponse(response);
     }
-    
+
     /**
      * Adding terms to a dictionary
      * @param dict The dictionary
@@ -531,7 +528,7 @@ export class Redisearch extends Module {
      */
     async config(command: 'GET' | 'SET' | 'HELP', option: string, value?: string): Promise<FTConfig> {
         const args = [command, option];
-        if(command === 'SET')
+        if (command === 'SET')
             args.push(value);
         const response = await this.sendCommand('FT.CONFIG', args);
         return this.handleResponse(response);
@@ -688,7 +685,7 @@ export type FTSearchParameters = {
         field: string,
         min: number,
         max: number
-    },
+    }[],
     geoFilter?: {
         field: string,
         lon: number,
@@ -698,13 +695,7 @@ export type FTSearchParameters = {
     },
     inKeys?: (string | number)[],
     inFields?: (string | number)[],
-    return?: {
-        num: number,
-        fields?: {
-            name: string,
-            as?: string
-        }[]
-    },
+    return?: string[],
     summarize?: {
         fields?: {
             num: number,

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -102,7 +102,7 @@ export class Redisearch extends Module {
             if (parameters.noContent === true)
                 args.push('NOCONTENT')
             if (parameters.verbatim === true)
-                args.push('VERBARIM')
+                args.push('VERBATIM')
             if (parameters.noStopWords === true)
                 args.push('NOSTOPWORDS')
             if (parameters.withScores === true)

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -87,6 +87,8 @@ export class Redisearch extends Module {
             if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator]);
             if (field.sortable !== undefined) args.push('SORTABLE');
             if (field.noindex !== undefined) args.push('NOINDEX');
+            if (field.unf !== undefined) args.push('UNF');
+            if (field.caseSensitive !== undefined) args.push('CASESENSITIVE');
         }
         const response = await this.sendCommand('FT.CREATE', args);
         return this.handleResponse(response);
@@ -589,6 +591,8 @@ export type FTFieldOptions = {
     phonetic?: string,
     weight?: number,
     seperator?: string
+    unf?: boolean,
+    caseSensitive?: boolean,
 }
 
 /**

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -125,7 +125,7 @@ export class Redisearch extends Module {
             if(parameters.inKeys !== undefined)
                 args = args.concat(['INKEYS', parameters.inKeys.num.toString(), parameters.inKeys.field])
             if(parameters.inFields !== undefined)
-                args = args.concat(['INFIELDS', parameters.inFields.num.toString(), parameters.inFields.field])
+                args = args.concat(['INFIELDS', parameters.inFields.num.toString()].concat(parameters.inFields.field))
             if(parameters.return !== undefined) {
                 args.push('RETURN');
                 if(parameters.return.num)
@@ -186,6 +186,7 @@ export class Redisearch extends Module {
             if(parameters.limit !== undefined)
                 args = args.concat(['LIMIT', parameters.limit.first.toString(), parameters.limit.num.toString()])
         }
+        console.log(args);
         const response = await this.sendCommand('FT.SEARCH', args);
         return this.handleResponse(response);
     }
@@ -701,7 +702,7 @@ export type FTSearchParameters = {
     },
     inFields?: {
         num: number,
-        field: string
+        field: string[]
     },
     return?: {
         num: number,

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -152,15 +152,12 @@ export class Redisearch extends Module {
                 args.push('HIGHLIGHT')
                 if (parameters.highlight.fields !== undefined) {
                     args.push('FIELDS')
-                    for (const field of parameters.highlight.fields) {
-                        args = args.concat([field.num.toString(), field.field]);
-                    }
+                    args.push(parameters.highlight.fields.length.toString());
+                    args = args.concat(parameters.highlight.fields);
                 }
                 if (parameters.highlight.tags !== undefined) {
                     args.push('TAGS')
-                    for (const tag of parameters.highlight.tags) {
-                        args = args.concat([tag.open, tag.close]);
-                    }
+                    args = args.concat([parameters.highlight.tags.open, parameters.highlight.tags.close]);
                 }
             }
             if (parameters.slop !== undefined)
@@ -702,14 +699,11 @@ export type FTSearchParameters = {
         seperator?: string
     },
     highlight?: {
-        fields?: {
-            num: number,
-            field: string
-        }[],
+        fields?: string[],
         tags?: {
             open: string,
             close: string
-        }[]
+        },
     },
     slop?: number,
     inOrder?: boolean,

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -81,14 +81,14 @@ export class Redisearch extends Module {
             if (field.as)
                 args = args.concat(['AS', field.as])
             args.push(field.type);
-            if (field.nostem !== undefined) args.push('NOSTEM');
+            if (field.nostem === true) args.push('NOSTEM');
             if (field.weight !== undefined) args = args.concat(['WEIGHT', field.weight.toString()]);
             if (field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic]);
             if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator]);
-            if (field.sortable !== undefined) args.push('SORTABLE');
-            if (field.noindex !== undefined) args.push('NOINDEX');
-            if (field.unf !== undefined) args.push('UNF');
-            if (field.caseSensitive !== undefined) args.push('CASESENSITIVE');
+            if (field.sortable === true) args.push('SORTABLE');
+            if (field.noindex === true) args.push('NOINDEX');
+            if (field.unf === true) args.push('UNF');
+            if (field.caseSensitive === true) args.push('CASESENSITIVE');
         }
         const response = await this.sendCommand('FT.CREATE', args);
         return this.handleResponse(response);

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -78,17 +78,17 @@ export class Redisearch extends Module {
         args.push('SCHEMA');
         for(const field of schemaFields) {
             args.push(field.name)
-            if (field.as !== undefined)
+            if(field.as !== undefined)
                 args = args.concat(['AS', field.as])
             args.push(field.type);
-            if (field.nostem === true) args.push('NOSTEM');
-            if (field.weight !== undefined) args = args.concat(['WEIGHT', `${field.weight}`])
-            if (field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic])
-            if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator])
-            if (field.sortable === true) args.push('SORTABLE')
-            if (field.noindex === true) args.push('NOINDEX')
-            if (field.unf === true) args.push('UNF')
-            if (field.caseSensitive === true) args.push('CASESENSITIVE')
+            if(field.nostem === true) args.push('NOSTEM');
+            if(field.weight !== undefined) args = args.concat(['WEIGHT', `${field.weight}`])
+            if(field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic])
+            if(field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator])
+            if(field.sortable === true) args.push('SORTABLE')
+            if(field.noindex === true) args.push('NOINDEX')
+            if(field.unf === true) args.push('UNF')
+            if(field.caseSensitive === true) args.push('CASESENSITIVE')
         }
         const response = await this.sendCommand('FT.CREATE', args);
         return this.handleResponse(response);
@@ -117,7 +117,7 @@ export class Redisearch extends Module {
             if(parameters.withSortKeys === true)
                 args.push('WITHSORTKEYS')
             if(parameters.filter !== undefined) {
-                for (const filterItem of parameters.filter) {
+                for(const filterItem of parameters.filter) {
                     args = args.concat(['FILTER', filterItem.field, `${filterItem.min}`, `${filterItem.max}`])
                 }
             }
@@ -138,7 +138,7 @@ export class Redisearch extends Module {
                 args.push('RETURN')
                 let itemCount = 0
                 let tempList = []
-                for (const returnItem of parameters.return) {
+                for(const returnItem of parameters.return) {
                     if(typeof returnItem === "string") {
                         //Strings can be pushed directly
                         tempList.push(returnItem)
@@ -322,14 +322,14 @@ export class Redisearch extends Module {
     async alter(index: string, field: string, fieldType: FTFieldType, options?: FTFieldOptions): Promise<'OK' | string> {
         let args = [index, 'SCHEMA', 'ADD', field, fieldType]
         if(options !== undefined) {
-            if (options.nostem === true) args.push('NOSTEM')
-            if (options.weight !== undefined) args = args.concat(['WEIGHT', `${options.weight}`])
-            if (options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic])
-            if (options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator])
-            if (options.sortable === true) args.push('SORTABLE')
-            if (options.noindex === true) args.push('NOINDEX')
-            if (options.unf === true) args.push('UNF')
-            if (options.caseSensitive === true) args.push('CASESENSITIVE')
+            if(options.nostem === true) args.push('NOSTEM')
+            if(options.weight !== undefined) args = args.concat(['WEIGHT', `${options.weight}`])
+            if(options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic])
+            if(options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator])
+            if(options.sortable === true) args.push('SORTABLE')
+            if(options.noindex === true) args.push('NOINDEX')
+            if(options.unf === true) args.push('UNF')
+            if(options.caseSensitive === true) args.push('CASESENSITIVE')
         }
         const response = await this.sendCommand('FT.ALTER', args);
         return this.handleResponse(response);
@@ -401,10 +401,10 @@ export class Redisearch extends Module {
      */
     async sugadd(key: string, suggestion: string, score: number, options?: FTSugAddParameters): Promise<number> {
         let args = [key, suggestion, score];
-        if (options !== undefined) {
-            if (options.incr === true)
+        if(options !== undefined) {
+            if(options.incr === true)
                 args.push('INCR');
-            if (options.payload !== undefined)
+            if(options.payload !== undefined)
                 args = args.concat(['PAYLOAD', options.payload]);
         }
         const response = await this.sendCommand('FT.SUGADD', args);
@@ -420,14 +420,14 @@ export class Redisearch extends Module {
      */
     async sugget(key: string, prefix: string, options?: FTSugGetParameters): Promise<string> {
         let args = [key, prefix];
-        if (options !== undefined) {
-            if (options.fuzzy === true)
+        if(options !== undefined) {
+            if(options.fuzzy === true)
                 args.push('FUZZY');
-            if (options.max !== undefined)
+            if(options.max !== undefined)
                 args = args.concat(['MAX', `${options.max}`]);
-            if (options.withScores === true)
+            if(options.withScores === true)
                 args.push('WITHSCORES');
-            if (options.withPayloads === true)
+            if(options.withPayloads === true)
                 args.push('WITHPAYLOADS');
         }
         const response = await this.sendCommand('FT.SUGGET', args);
@@ -463,7 +463,7 @@ export class Redisearch extends Module {
      */
     async synupdate(index: string, groupId: number, terms: string[], skipInitialScan = false): Promise<'OK'> {
         let args = [index, groupId];
-        if (skipInitialScan === true)
+        if(skipInitialScan === true)
             args.push('SKIPINITIALSCAN');
         args = args.concat(terms);
         const response = await this.sendCommand('FT.SYNUPDATE', args);
@@ -489,12 +489,12 @@ export class Redisearch extends Module {
      */
     async spellcheck(index: string, query: string, options?: FTSpellCheck): Promise<string[]> {
         let args = [index, query];
-        if (options !== undefined) {
-            if (options.distance !== undefined)
+        if(options !== undefined) {
+            if(options.distance !== undefined)
                 args = args.concat(['DISTANCE', `${options.distance}`]);
-            if (options.terms !== undefined) {
+            if(options.terms !== undefined) {
                 args.push('TERMS');
-                for (const term of options.terms) {
+                for(const term of options.terms) {
                     args = args.concat([term.type, term.dict]);
                 }
             }

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -39,16 +39,16 @@ export class Redisearch extends Module {
         let args: string[] = [index, 'ON', indexType]
         if(parameters !== undefined) {
             if(parameters.prefix !== undefined) {
-                args.push('PREFIX');
-                args.push(`${parameters.prefix.length}`);
-                args = args.concat(parameters.prefix);
+                args.push('PREFIX')
+                args.push(`${parameters.prefix.length}`)
+                args = args.concat(parameters.prefix)
             }
             if(parameters.filter !== undefined)
                 args = args.concat(['FILTER', parameters.filter])
             if(parameters.language !== undefined)
                 args = args.concat(['LANGUAGE', parameters.language]);
             if(parameters.languageField !== undefined)
-                args = args.concat(['LANGUAGE_FIELD', parameters.languageField]);
+                args = args.concat(['LANGUAGE_FIELD', parameters.languageField])
             if(parameters.score !== undefined)
                 args = args.concat(['SCORE', parameters.score])
             if(parameters.scoreField !== undefined)
@@ -58,22 +58,22 @@ export class Redisearch extends Module {
             if(parameters.maxTextFields !== undefined)
                 args = args.concat(['MAXTEXTFIELDS', `${parameters.maxTextFields}`])
             if(parameters.temporary !== undefined)
-                args = args.concat(['TEMPORARY', `${parameters.temporary}`]);
+                args = args.concat(['TEMPORARY', `${parameters.temporary}`])
             if(parameters.noOffsets === true)
-                args.push('NOOFFSETS');
+                args.push('NOOFFSETS')
             if(parameters.nohl === true)
-                args.push('NOHL');
+                args.push('NOHL')
             if(parameters.noFields === true)
-                args.push('NOFIELDS');
+                args.push('NOFIELDS')
             if(parameters.noFreqs === true)
-                args.push('NOFREQS');
+                args.push('NOFREQS')
             if(parameters.stopwords !== undefined) {
-                args.push('STOPWORDS');
-                args.push(`${parameters.stopwords.length}`);
-                args = args.concat(parameters.stopwords);
+                args.push('STOPWORDS')
+                args.push(`${parameters.stopwords.length}`)
+                args = args.concat(parameters.stopwords)
             }
             if(parameters.skipInitialScan !== undefined)
-                args.push('SKIPINITIALSCAN');
+                args.push('SKIPINITIALSCAN')
         }
         args.push('SCHEMA');
         for(const field of schemaFields) {
@@ -82,13 +82,13 @@ export class Redisearch extends Module {
                 args = args.concat(['AS', field.as])
             args.push(field.type);
             if (field.nostem === true) args.push('NOSTEM');
-            if (field.weight !== undefined) args = args.concat(['WEIGHT', `${field.weight}`]);
-            if (field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic]);
-            if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator]);
-            if (field.sortable === true) args.push('SORTABLE');
-            if (field.noindex === true) args.push('NOINDEX');
-            if (field.unf === true) args.push('UNF');
-            if (field.caseSensitive === true) args.push('CASESENSITIVE');
+            if (field.weight !== undefined) args = args.concat(['WEIGHT', `${field.weight}`])
+            if (field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic])
+            if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator])
+            if (field.sortable === true) args.push('SORTABLE')
+            if (field.noindex === true) args.push('NOINDEX')
+            if (field.unf === true) args.push('UNF')
+            if (field.caseSensitive === true) args.push('CASESENSITIVE')
         }
         const response = await this.sendCommand('FT.CREATE', args);
         return this.handleResponse(response);
@@ -117,8 +117,8 @@ export class Redisearch extends Module {
             if(parameters.withSortKeys === true)
                 args.push('WITHSORTKEYS')
             if(parameters.filter !== undefined) {
-                for (const item of parameters.filter) {
-                    args = args.concat(['FILTER', item.field, `${item.min}`, `${item.max}`])
+                for (const filterItem of parameters.filter) {
+                    args = args.concat(['FILTER', filterItem.field, `${filterItem.min}`, `${filterItem.max}`])
                 }
             }
             if(parameters.geoFilter !== undefined)
@@ -137,30 +137,30 @@ export class Redisearch extends Module {
             if(parameters.return !== undefined) {
                 args.push('RETURN')
                 //Else we need to expand the objects
-                let itemCount = 0;
-                let tempList = [];
-                for (const item of parameters.return) {
-                    if(typeof item === "string") {
-                        tempList.push(item);
-                        itemCount++;
+                let itemCount = 0
+                let tempList = []
+                for (const returnItem of parameters.return) {
+                    if(typeof returnItem === "string") {
+                        tempList.push(returnItem)
+                        itemCount++
                     } else {
-                        tempList.push(item.field);
-                        itemCount++;
-                        if(item.as !== undefined) {
-                            tempList = tempList.concat(["AS", item.as]);
-                            itemCount += 2;
+                        tempList.push(returnItem.field)
+                        itemCount++
+                        if(returnItem.as !== undefined) {
+                            tempList = tempList.concat(["AS", returnItem.as])
+                            itemCount += 2
                         }
                     }
                 }
-                args.push(`${itemCount}`);
-                args = args.concat(tempList);
+                args.push(`${itemCount}`)
+                args = args.concat(tempList)
             }
             if(parameters.summarize !== undefined) {
                 args.push('SUMMARIZE')
                 if(parameters.summarize.fields !== undefined) {
                     args.push('FIELDS')
                     args.push(`${parameters.summarize.fields.length}`)
-                    args = args.concat(parameters.summarize.fields);
+                    args = args.concat(parameters.summarize.fields)
                 }
                 if(parameters.summarize.frags !== undefined)
                     args = args.concat(['FRAGS', `${parameters.summarize.frags}`])
@@ -173,12 +173,12 @@ export class Redisearch extends Module {
                 args.push('HIGHLIGHT')
                 if(parameters.highlight.fields !== undefined) {
                     args.push('FIELDS')
-                    args.push(`${parameters.highlight.fields.length}`);
-                    args = args.concat(parameters.highlight.fields);
+                    args.push(`${parameters.highlight.fields.length}`)
+                    args = args.concat(parameters.highlight.fields)
                 }
                 if(parameters.highlight.tags !== undefined) {
                     args.push('TAGS')
-                    args = args.concat([parameters.highlight.tags.open, parameters.highlight.tags.close]);
+                    args = args.concat([parameters.highlight.tags.open, parameters.highlight.tags.close])
                 }
             }
             if(parameters.slop !== undefined)
@@ -321,14 +321,14 @@ export class Redisearch extends Module {
     async alter(index: string, field: string, fieldType: FTFieldType, options?: FTFieldOptions): Promise<'OK' | string> {
         let args = [index, 'SCHEMA', 'ADD', field, fieldType]
         if(options !== undefined) {
-            if (options.nostem === true) args.push('NOSTEM');
-            if (options.weight !== undefined) args = args.concat(['WEIGHT', `${options.weight}`]);
-            if (options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic]);
-            if (options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator]);
-            if (options.sortable === true) args.push('SORTABLE');
-            if (options.noindex === true) args.push('NOINDEX');
-            if (options.unf === true) args.push('UNF');
-            if (options.caseSensitive === true) args.push('CASESENSITIVE');
+            if (options.nostem === true) args.push('NOSTEM')
+            if (options.weight !== undefined) args = args.concat(['WEIGHT', `${options.weight}`])
+            if (options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic])
+            if (options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator])
+            if (options.sortable === true) args.push('SORTABLE')
+            if (options.noindex === true) args.push('NOINDEX')
+            if (options.unf === true) args.push('UNF')
+            if (options.caseSensitive === true) args.push('CASESENSITIVE')
         }
         const response = await this.sendCommand('FT.ALTER', args);
         return this.handleResponse(response);

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -875,7 +875,7 @@ export interface FTSearchParameters {
 /**
  * The additional parameter of 'FT.AGGREGATE' command
  */
-export type FTAggregateParameters = {
+export interface FTAggregateParameters {
     /**
      * The 'LOAD' parameter. 
      */
@@ -1046,7 +1046,7 @@ export interface FTSugGetParameters {
 /**
  * The additional parameters of 'FT.SPELLCHECK' command
  */
-export type FTSpellCheck = {
+export interface FTSpellCheck {
     /**
      * A list of terms
      */

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -37,52 +37,52 @@ export class Redisearch extends Module {
      */
     async create(index: string, indexType: FTIndexType, schemaFields: FTSchemaField[], parameters?: FTCreateParameters): Promise<'OK' | string> {
         let args: string[] = [index, 'ON', indexType]
-        if (parameters !== undefined) {
-            if (parameters.prefix !== undefined) {
+        if(parameters !== undefined) {
+            if(parameters.prefix !== undefined) {
                 args.push('PREFIX');
-                args.push(parameters.prefix.length.toString());
+                args.push(`${parameters.prefix.length}`);
                 args = args.concat(parameters.prefix);
             }
-            if (parameters.filter !== undefined)
+            if(parameters.filter !== undefined)
                 args = args.concat(['FILTER', parameters.filter])
-            if (parameters.language !== undefined)
+            if(parameters.language !== undefined)
                 args = args.concat(['LANGUAGE', parameters.language]);
-            if (parameters.languageField !== undefined)
+            if(parameters.languageField !== undefined)
                 args = args.concat(['LANGUAGE_FIELD', parameters.languageField]);
-            if (parameters.score !== undefined)
+            if(parameters.score !== undefined)
                 args = args.concat(['SCORE', parameters.score])
-            if (parameters.scoreField !== undefined)
+            if(parameters.scoreField !== undefined)
                 args = args.concat(['SCORE_FIELD', parameters.scoreField])
-            if (parameters.payloadField !== undefined)
+            if(parameters.payloadField !== undefined)
                 args = args.concat(['PAYLOAD_FIELD', parameters.payloadField])
-            if (parameters.maxTextFields !== undefined)
-                args = args.concat(['MAXTEXTFIELDS', parameters.maxTextFields.toString()])
-            if (parameters.temporary !== undefined)
-                args = args.concat(['TEMPORARY', parameters.temporary.toString()]);
-            if (parameters.noOffsets === true)
+            if(parameters.maxTextFields !== undefined)
+                args = args.concat(['MAXTEXTFIELDS', `${parameters.maxTextFields}`])
+            if(parameters.temporary !== undefined)
+                args = args.concat(['TEMPORARY', `${parameters.temporary}`]);
+            if(parameters.noOffsets === true)
                 args.push('NOOFFSETS');
-            if (parameters.nohl === true)
+            if(parameters.nohl === true)
                 args.push('NOHL');
-            if (parameters.noFields === true)
+            if(parameters.noFields === true)
                 args.push('NOFIELDS');
-            if (parameters.noFreqs === true)
+            if(parameters.noFreqs === true)
                 args.push('NOFREQS');
-            if (parameters.stopwords !== undefined) {
+            if(parameters.stopwords !== undefined) {
                 args.push('STOPWORDS');
-                args.push(parameters.stopwords.length.toString());
+                args.push(`${parameters.stopwords.length}`);
                 args = args.concat(parameters.stopwords);
             }
-            if (parameters.skipInitialScan !== undefined)
+            if(parameters.skipInitialScan !== undefined)
                 args.push('SKIPINITIALSCAN');
         }
         args.push('SCHEMA');
-        for (const field of schemaFields) {
+        for(const field of schemaFields) {
             args.push(field.name)
             if (field.as !== undefined)
                 args = args.concat(['AS', field.as])
             args.push(field.type);
             if (field.nostem === true) args.push('NOSTEM');
-            if (field.weight !== undefined) args = args.concat(['WEIGHT', field.weight.toString()]);
+            if (field.weight !== undefined) args = args.concat(['WEIGHT', `${field.weight}`]);
             if (field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic]);
             if (field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator]);
             if (field.sortable === true) args.push('SORTABLE');
@@ -103,102 +103,102 @@ export class Redisearch extends Module {
      */
     async search(index: string, query: string, parameters?: FTSearchParameters): Promise<[number, ...Array<string | string[]>]> {
         let args: string[] = [index, query];
-        if (parameters !== undefined) {
-            if (parameters.noContent === true)
+        if(parameters !== undefined) {
+            if(parameters.noContent === true)
                 args.push('NOCONTENT')
-            if (parameters.verbatim === true)
+            if(parameters.verbatim === true)
                 args.push('VERBATIM')
-            if (parameters.noStopWords === true)
+            if(parameters.noStopWords === true)
                 args.push('NOSTOPWORDS')
-            if (parameters.withScores === true)
+            if(parameters.withScores === true)
                 args.push('WITHSCORES')
-            if (parameters.withPayloads === true)
+            if(parameters.withPayloads === true)
                 args.push('WITHPAYLOADS')
-            if (parameters.withSortKeys === true)
+            if(parameters.withSortKeys === true)
                 args.push('WITHSORTKEYS')
-            if (parameters.filter !== undefined) {
+            if(parameters.filter !== undefined) {
                 for (const item of parameters.filter) {
-                    args = args.concat(['FILTER', item.field, item.min.toString(), item.max.toString()])
+                    args = args.concat(['FILTER', item.field, `${item.min}`, `${item.max}`])
                 }
             }
-            if (parameters.geoFilter !== undefined)
+            if(parameters.geoFilter !== undefined)
                 args = args.concat([
                     'GEOFILTER',
                     parameters.geoFilter.field,
-                    parameters.geoFilter.lon.toString(),
-                    parameters.geoFilter.lat.toString(),
-                    parameters.geoFilter.radius.toString(),
+                    `${parameters.geoFilter.lon}`,
+                    `${parameters.geoFilter.lat}`,
+                    `${parameters.geoFilter.radius}`,
                     parameters.geoFilter.measurement
                 ])
-            if (parameters.inKeys !== undefined)
-                args = args.concat(['INKEYS', parameters.inKeys.length.toString()].concat(parameters.inKeys.map(f => f.toString())))
-            if (parameters.inFields !== undefined)
-                args = args.concat(['INFIELDS', parameters.inFields.length.toString()].concat(parameters.inFields.map(f => f.toString())))
-            if (parameters.return !== undefined) {
+            if(parameters.inKeys !== undefined)
+                args = args.concat(['INKEYS', `${parameters.inKeys.length}`].concat(parameters.inKeys.map(inKeysItem => `${inKeysItem}`)))
+            if(parameters.inFields !== undefined)
+                args = args.concat(['INFIELDS', `${parameters.inFields.length}`].concat(parameters.inFields.map(inFieldItem => `${inFieldItem}`)))
+            if(parameters.return !== undefined) {
                 args.push('RETURN')
                 //Else we need to expand the objects
                 let itemCount = 0;
                 let tempList = [];
                 for (const item of parameters.return) {
-                    if (typeof item === "string") {
+                    if(typeof item === "string") {
                         tempList.push(item);
                         itemCount++;
                     } else {
                         tempList.push(item.field);
                         itemCount++;
-                        if (item.as !== undefined) {
+                        if(item.as !== undefined) {
                             tempList = tempList.concat(["AS", item.as]);
                             itemCount += 2;
                         }
                     }
                 }
-                args.push(itemCount.toString());
+                args.push(`${itemCount}`);
                 args = args.concat(tempList);
             }
-            if (parameters.summarize !== undefined) {
+            if(parameters.summarize !== undefined) {
                 args.push('SUMMARIZE')
-                if (parameters.summarize.fields !== undefined) {
+                if(parameters.summarize.fields !== undefined) {
                     args.push('FIELDS')
-                    args.push(parameters.summarize.fields.length.toString())
+                    args.push(`${parameters.summarize.fields.length}`)
                     args = args.concat(parameters.summarize.fields);
                 }
-                if (parameters.summarize.frags !== undefined)
-                    args = args.concat(['FRAGS', parameters.summarize.frags.toString()])
-                if (parameters.summarize.len !== undefined)
-                    args = args.concat(['LEN', parameters.summarize.len.toString()])
-                if (parameters.summarize.seperator !== undefined)
+                if(parameters.summarize.frags !== undefined)
+                    args = args.concat(['FRAGS', `${parameters.summarize.frags}`])
+                if(parameters.summarize.len !== undefined)
+                    args = args.concat(['LEN', `${parameters.summarize.len}`])
+                if(parameters.summarize.seperator !== undefined)
                     args = args.concat(['SEPARATOR', parameters.summarize.seperator])
             }
-            if (parameters.highlight !== undefined) {
+            if(parameters.highlight !== undefined) {
                 args.push('HIGHLIGHT')
-                if (parameters.highlight.fields !== undefined) {
+                if(parameters.highlight.fields !== undefined) {
                     args.push('FIELDS')
-                    args.push(parameters.highlight.fields.length.toString());
+                    args.push(`${parameters.highlight.fields.length}`);
                     args = args.concat(parameters.highlight.fields);
                 }
-                if (parameters.highlight.tags !== undefined) {
+                if(parameters.highlight.tags !== undefined) {
                     args.push('TAGS')
                     args = args.concat([parameters.highlight.tags.open, parameters.highlight.tags.close]);
                 }
             }
-            if (parameters.slop !== undefined)
-                args = args.concat(['SLOP', parameters.slop.toString()])
-            if (parameters.inOrder === true)
+            if(parameters.slop !== undefined)
+                args = args.concat(['SLOP', `${parameters.slop}`])
+            if(parameters.inOrder === true)
                 args.push('INORDER')
-            if (parameters.language !== undefined)
+            if(parameters.language !== undefined)
                 args = args.concat(['LANGUAGE', parameters.language])
-            if (parameters.expander !== undefined)
+            if(parameters.expander !== undefined)
                 args = args.concat(['EXPANDER', parameters.expander])
-            if (parameters.scorer !== undefined)
+            if(parameters.scorer !== undefined)
                 args = args.concat(['SCORER', parameters.scorer])
-            if (parameters.explainScore === true)
+            if(parameters.explainScore === true)
                 args.push('EXPLAINSCORE')
-            if (parameters.payload)
+            if(parameters.payload)
                 args = args.concat(['PAYLOAD', parameters.payload])
-            if (parameters.sortBy !== undefined)
+            if(parameters.sortBy !== undefined)
                 args = args.concat(['SORTBY', parameters.sortBy.field, parameters.sortBy.sort])
-            if (parameters.limit !== undefined)
-                args = args.concat(['LIMIT', parameters.limit.first.toString(), parameters.limit.num.toString()])
+            if(parameters.limit !== undefined)
+                args = args.concat(['LIMIT', `${parameters.limit.first}`, `${parameters.limit.num}`])
         }
         const response = await this.sendCommand('FT.SEARCH', args);
         return this.handleResponse(response, true);
@@ -213,75 +213,75 @@ export class Redisearch extends Module {
      */
     async aggregate(index: string, query: string, parameters?: FTAggregateParameters): Promise<[number, ...Array<string[]>]> {
         let args: string[] = [index, query];
-        if (parameters !== undefined) {
-            if (parameters.load !== undefined) {
+        if(parameters !== undefined) {
+            if(parameters.load !== undefined) {
                 args.push('LOAD')
-                if (parameters.load.nargs !== undefined)
+                if(parameters.load.nargs !== undefined)
                     args.push(parameters.load.nargs);
-                if (parameters.load.properties !== undefined)
+                if(parameters.load.properties !== undefined)
                     parameters.load.properties.forEach(property => {
                         args.push(property);
                     })
             }
-            if (parameters.apply !== undefined) {
+            if(parameters.apply !== undefined) {
                 parameters.apply.forEach(apply => {
                     args.push('APPLY');
                     args.push(apply.expression);
-                    if (apply.as)
+                    if(apply.as)
                         args = args.concat(['AS', apply.as]);
                 })
             }
-            if (parameters.groupby !== undefined) {
+            if(parameters.groupby !== undefined) {
                 args.push('GROUPBY')
-                if (parameters.groupby.nargs !== undefined)
+                if(parameters.groupby.nargs !== undefined)
                     args.push(parameters.groupby.nargs);
-                if (parameters.groupby.properties !== undefined) {
+                if(parameters.groupby.properties !== undefined) {
                     parameters.groupby.properties.forEach((property) => {
                         args.push(property);
                     })
                 }
             }
-            if (parameters.reduce !== undefined) {
+            if(parameters.reduce !== undefined) {
                 parameters.reduce.forEach(reduce => {
                     args.push('REDUCE')
-                    if (reduce.function !== undefined)
+                    if(reduce.function !== undefined)
                         args.push(reduce.function);
-                    if (reduce.nargs !== undefined)
+                    if(reduce.nargs !== undefined)
                         args.push(reduce.nargs);
-                    if (reduce.args)
+                    if(reduce.args)
                         reduce.args.forEach(arg => {
                             args.push(arg);
                         })
-                    if (reduce.as !== undefined)
+                    if(reduce.as !== undefined)
                         args = args.concat(['AS', reduce.as]);
                 })
             }
-            if (parameters.sortby !== undefined) {
+            if(parameters.sortby !== undefined) {
                 args.push('SORTBY')
-                if (parameters.sortby.nargs !== undefined)
+                if(parameters.sortby.nargs !== undefined)
                     args.push(parameters.sortby.nargs);
-                if (parameters.sortby.properties)
+                if(parameters.sortby.properties)
                     parameters.sortby.properties.forEach(property => {
                         args.push(property.property);
                         args.push(property.sort);
                     })
-                if (parameters.sortby.max !== undefined)
-                    args = args.concat(['MAX', parameters.sortby.max.toString()]);
+                if(parameters.sortby.max !== undefined)
+                    args = args.concat(['MAX', `${parameters.sortby.max}`]);
             }
-            if (parameters.expressions !== undefined) {
+            if(parameters.expressions !== undefined) {
                 parameters.expressions.forEach(expression => {
                     args.push('APPLY');
                     args.push(expression.expression);
-                    if (expression.as)
+                    if(expression.as)
                         args = args.concat(['AS', expression.as]);
                 })
             }
-            if (parameters.limit !== undefined) {
+            if(parameters.limit !== undefined) {
                 args.push('LIMIT')
-                if (parameters.limit.offset !== undefined)
+                if(parameters.limit.offset !== undefined)
                     args.push(parameters.limit.offset)
-                if (parameters.limit.numberOfResults !== undefined)
-                    args.push(parameters.limit.numberOfResults.toString());
+                if(parameters.limit.numberOfResults !== undefined)
+                    args.push(`${parameters.limit.numberOfResults}`);
             }
         }
         const response = await this.sendCommand('FT.AGGREGATE', args);
@@ -320,9 +320,9 @@ export class Redisearch extends Module {
      */
     async alter(index: string, field: string, fieldType: FTFieldType, options?: FTFieldOptions): Promise<'OK' | string> {
         let args = [index, 'SCHEMA', 'ADD', field, fieldType]
-        if (options !== undefined) {
+        if(options !== undefined) {
             if (options.nostem === true) args.push('NOSTEM');
-            if (options.weight !== undefined) args = args.concat(['WEIGHT', options.weight.toString()]);
+            if (options.weight !== undefined) args = args.concat(['WEIGHT', `${options.weight}`]);
             if (options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic]);
             if (options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator]);
             if (options.sortable === true) args.push('SORTABLE');
@@ -342,7 +342,7 @@ export class Redisearch extends Module {
      */
     async dropindex(index: string, deleteHash = false): Promise<'OK' | string> {
         const args = [index];
-        if (deleteHash === true) args.push('DD')
+        if(deleteHash === true) args.push('DD')
         const response = await this.sendCommand('FT.DROPINDEX', args);
         return this.handleResponse(response);
     }
@@ -423,7 +423,7 @@ export class Redisearch extends Module {
             if (options.fuzzy === true)
                 args.push('FUZZY');
             if (options.max !== undefined)
-                args = args.concat(['MAX', options.max.toString()]);
+                args = args.concat(['MAX', `${options.max}`]);
             if (options.withScores === true)
                 args.push('WITHSCORES');
             if (options.withPayloads === true)
@@ -474,7 +474,7 @@ export class Redisearch extends Module {
      * @param index The index
      * @returns A list of synonym terms and their synonym group ids.  
      */
-    async syndump(index: string): Promise<{ [key: string]: string | number }> {
+    async syndump(index: string): Promise<{[key: string]: string | number}> {
         const response = await this.sendCommand('FT.SYNDUMP', [index]);
         return this.handleResponse(response);
     }
@@ -490,7 +490,7 @@ export class Redisearch extends Module {
         let args = [index, query];
         if (options !== undefined) {
             if (options.distance !== undefined)
-                args = args.concat(['DISTANCE', options.distance.toString()]);
+                args = args.concat(['DISTANCE', `${options.distance}`]);
             if (options.terms !== undefined) {
                 args.push('TERMS');
                 for (const term of options.terms) {
@@ -553,7 +553,7 @@ export class Redisearch extends Module {
      */
     async config(command: 'GET' | 'SET' | 'HELP', option: string, value?: string): Promise<FTConfig> {
         const args = [command, option];
-        if (command === 'SET')
+        if(command === 'SET')
             args.push(value);
         const response = await this.sendCommand('FT.CONFIG', args);
         return this.handleResponse(response);

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -138,9 +138,8 @@ export class Redisearch extends Module {
                 args.push('SUMMARIZE')
                 if (parameters.summarize.fields !== undefined) {
                     args.push('FIELDS')
-                    for (const field of parameters.summarize.fields) {
-                        args = args.concat([field.num.toString(), field.field]);
-                    }
+                    args.push(parameters.summarize.fields.length.toString())
+                    args = args.concat(parameters.summarize.fields);
                 }
                 if (parameters.summarize.frags !== undefined)
                     args = args.concat(['FRAGS', parameters.summarize.frags.toString()])
@@ -697,10 +696,7 @@ export type FTSearchParameters = {
     inFields?: (string | number)[],
     return?: string[],
     summarize?: {
-        fields?: {
-            num: number,
-            field: string
-        }[],
+        fields?: string[],
         frags?: number,
         len?: number,
         seperator?: string

--- a/modules/redisearch.ts
+++ b/modules/redisearch.ts
@@ -67,8 +67,11 @@ export class Redisearch extends Module {
                 args.push('NOFIELDS');
             if (parameters.noFreqs !== undefined)
                 args.push('NOFREQS');
-            if (parameters.stopwords !== undefined)
-                args = args.concat(['STOPWORDS', parameters.stopwords.num.toString(), parameters.stopwords.stopword]);
+            if (parameters.stopwords !== undefined) {
+                args.push('STOPWORDS');
+                args.push(parameters.stopwords.length.toString());
+                args = args.concat(parameters.stopwords);
+            }
             if (parameters.skipInitialScan !== undefined)
                 args.push('SKIPINITIALSCAN');
         }
@@ -567,10 +570,7 @@ export type FTCreateParameters = {
     languageField?: string,
     score?: string,
     scoreField?: string
-    stopwords?: {
-        num: number,
-        stopword: string
-    }
+    stopwords?: string[],
 }
 
 /**

--- a/modules/rts.ts
+++ b/modules/rts.ts
@@ -255,14 +255,14 @@ export class RedisTimeSeries extends Module {
     async mrange(fromTimestamp: string, toTimestamp: string, filter: string, options?: TSMRangeOptions): Promise<(string | number)[][]> {
         let args = [fromTimestamp, toTimestamp];
         if(options !== undefined && options.count !== undefined)
-            args = args.concat(['COUNT', options.count.toString()]);
-        if(options !== undefined && options.aggregation !== undefined)
-            args = args.concat(['AGGREGATION', options.aggregation.type, options.aggregation.timeBucket.toString()]);
-        if(options !== undefined && options.withLabels !== undefined)
+            args = args.concat(['COUNT', `${options.count}`]);
+        if(options !== undefined && options.aggregation)
+            args = args.concat(['AGGREGATION', `${options.aggregation.type}`, `${options.aggregation.timeBucket}`]);
+        if(options !== undefined && options.withLabels === true)
             args.push('WITHLABELS')
+        args = args.concat(['FILTER', `${filter}`])
         if(options !== undefined && options.groupBy)
-            args = args.concat(['GROUPBY', options.groupBy.label, 'REDUCE', options.groupBy.reducer])
-        args = args.concat(['FILTER', filter])
+            args = args.concat(['GROUPBY', `${options.groupBy.label}`, 'REDUCE', `${options.groupBy.reducer}`])
         return await this.sendCommand('TS.MRANGE', args)
     }
     

--- a/modules/rts.ts
+++ b/modules/rts.ts
@@ -1,4 +1,3 @@
-
 import * as Redis from 'ioredis';
 import { Module, RedisModuleOptions } from './module.base';
 
@@ -212,12 +211,8 @@ export class RedisTimeSeries extends Module {
      * @param options.aggregation.timeBucket The time bucket of the 'AGGREGATION' command
      */
     async range(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): Promise<number[]> {
-        let args = [key, fromTimestamp, toTimestamp];
-        if(options !== undefined && options.count !== undefined)
-            args = args.concat(['COUNT', options.count.toString()]);
-        if(options !== undefined && options.aggregation !== undefined)
-            args = args.concat(['AGGREGATION', options.aggregation.type, options.aggregation.timeBucket.toString()]);
-        return await this.sendCommand('TS.RANGE', args)
+        const args = this.buildRangeCommand(key, fromTimestamp, toTimestamp, options);
+        return await this.sendCommand('TS.RANGE', args);
     }
     
     /**
@@ -232,12 +227,30 @@ export class RedisTimeSeries extends Module {
      * @param options.aggregation.timeBucket The time bucket of the 'AGGREGATION' command
      */
     async revrange(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): Promise<number[]> {
-        let args = [key, fromTimestamp.toString(), toTimestamp.toString()];
-        if(options !== undefined && options.count !== undefined)
-            args = args.concat(['COUNT', options.count.toString()]);
-        if(options !== undefined && options.aggregation !== undefined)
-            args = args.concat(['AGGREGATION', options.aggregation.type, options.aggregation.timeBucket.toString()]);
+        const args = this.buildRangeCommand(key, fromTimestamp, toTimestamp, options);
         return await this.sendCommand('TS.REVRANGE', args)
+    }
+
+    /**
+     * Building the arguments for 'TS.RANGE'/'TS.REVRANGE' commands
+     * @param key The key
+     * @param fromTimestamp The starting timestamp
+     * @param toTimestamp The ending timestamp
+     * @param options The 'TS.RANGE'/'TS.REVRANGE' command optional parameters
+     * @returns The arguments of the command
+     */
+    buildRangeCommand(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): string[] {
+        let args = [key, fromTimestamp, toTimestamp];
+        if(options?.count !== undefined){
+            args = args.concat(['COUNT', `${options.count}`]);
+        }
+        if(options?.align !== undefined){
+            args = args.concat(['ALIGN', `${options.align}`]);
+        }
+        if(options?.aggregation !== undefined){
+            args = args.concat(['AGGREGATION', options.aggregation.type, `${options.aggregation.timeBucket}`]);
+        }
+        return args;
     }
 
     /**
@@ -253,16 +266,7 @@ export class RedisTimeSeries extends Module {
      * @param options.withLabels The 'WITHLABELS' optional parameter
      */
     async mrange(fromTimestamp: string, toTimestamp: string, filter: string, options?: TSMRangeOptions): Promise<(string | number)[][]> {
-        let args = [fromTimestamp, toTimestamp];
-        if(options !== undefined && options.count !== undefined)
-            args = args.concat(['COUNT', `${options.count}`]);
-        if(options !== undefined && options.aggregation)
-            args = args.concat(['AGGREGATION', `${options.aggregation.type}`, `${options.aggregation.timeBucket}`]);
-        if(options !== undefined && options.withLabels === true)
-            args.push('WITHLABELS')
-        args = args.concat(['FILTER', `${filter}`])
-        if(options !== undefined && options.groupBy)
-            args = args.concat(['GROUPBY', `${options.groupBy.label}`, 'REDUCE', `${options.groupBy.reducer}`])
+        const args = this.buildMultiRangeCommand(fromTimestamp, toTimestamp, filter, options);
         return await this.sendCommand('TS.MRANGE', args)
     }
     
@@ -279,19 +283,39 @@ export class RedisTimeSeries extends Module {
      * @param options.withLabels The 'WITHLABELS' optional parameter
      */
     async mrevrange(fromTimestamp: string, toTimestamp: string, filter: string, options?: TSMRangeOptions): Promise<(string | number)[][]> {
-        let args = [fromTimestamp, toTimestamp];
-        if(options !== undefined && options.count !== undefined)
-            args = args.concat(['COUNT', options.count.toString()]);
-        if(options !== undefined && options.aggregation !== undefined)
-            args = args.concat(['AGGREGATION', options.aggregation.type, options.aggregation.timeBucket.toString()]);
-        if(options !== undefined && options.withLabels !== undefined)
-            args.push('WITHLABELS')
-        if(options !== undefined && options.groupBy)
-            args = args.concat(['GROUPBY', options.groupBy.label, 'REDUCE', options.groupBy.reducer])
-        args = args.concat(['FILTER', filter])
+        const args = this.buildMultiRangeCommand(fromTimestamp, toTimestamp, filter, options);
         return await this.sendCommand('TS.MREVRANGE', args)
     }
 
+    /**
+     * Building the arguments for 'TS.MRANGE'/'TS.MREVRANGE' commands
+     * @param fromTimestamp The starting timestamp
+     * @param toTimestamp The ending timestamp
+     * @param filter The filter
+     * @param options The 'TS.MRANGE'/'TS.MREVRANGE' command optional parameters 
+     * @returns The arguments of the command
+     */
+    buildMultiRangeCommand(fromTimestamp: string, toTimestamp: string, filter: string, options?: TSMRangeOptions): string[] {
+        let args = [fromTimestamp, toTimestamp];
+        if(options?.count !== undefined) {
+            args = args.concat(['COUNT', `${options.count}`]);
+        }
+        if(options?.align !== undefined){
+            args = args.concat(['ALIGN', `${options.align}`]);
+        }
+        if(options?.aggregation){
+            args = args.concat(['AGGREGATION', `${options.aggregation.type}`, `${options.aggregation.timeBucket}`]);
+        }
+        if(options?.withLabels === true) {
+            args.push('WITHLABELS')
+        }
+        args = args.concat(['FILTER', `${filter}`])
+        if(options?.groupBy){
+            args = args.concat(['GROUPBY', `${options.groupBy.label}`, 'REDUCE', `${options.groupBy.reducer}`])
+        }
+        return args;
+    }
+    
     /**
      * Retrieving the last sample of a key
      * @param key The key
@@ -467,6 +491,7 @@ export type TSAggregationType = 'avg' | 'sum' | 'min' | 'max' | 'range' | 'range
 
 /**
  * The 'TS.Range' command optional parameters
+ * @param align The 'ALIGN' optional parameter
  * @param count The 'COUNT' optional parameter
  * @param aggregation The 'AGGREGATION' optional parameter
  * @param aggregation.type The type of the 'AGGREGATION' command
@@ -474,6 +499,7 @@ export type TSAggregationType = 'avg' | 'sum' | 'min' | 'max' | 'range' | 'range
  */
 export type TSRangeOptions = {
     count?: number,
+    align?: TSAlignType,
     aggregation?: {
         type: TSAggregationType,
         timeBucket: number
@@ -498,3 +524,12 @@ export interface TSMRangeOptions extends TSRangeOptions {
         reducer: 'SUM' | 'MIN' | 'MAX'
     }
 }
+
+/**
+ * The available values of Align aggregation
+ * @param start The reference timestamp will be the query start interval time (fromTimestamp).
+ * @param + The reference timestamp will be the query start interval time (fromTimestamp).
+ * @param end The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
+ * @param - The reference timestamp will be the signed remainder of query end interval time by the AGGREGATION time bucket (toTimestamp % timeBucket).
+ */
+ export type TSAlignType = 'start' | '+' | 'end' | '-';

--- a/modules/rts.ts
+++ b/modules/rts.ts
@@ -239,8 +239,14 @@ export class RedisTimeSeries extends Module {
      * @param options The 'TS.RANGE'/'TS.REVRANGE' command optional parameters
      * @returns The arguments of the command
      */
-    buildRangeCommand(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): string[] {
+    private buildRangeCommand(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): string[] {
         let args = [key, fromTimestamp, toTimestamp];
+        if(options?.filterByTS !== undefined) {
+            args = args.concat(['FILTER_BY_TS', options.filterByTS.join(' ')]);
+        }
+        if(options?.filterByValue !== undefined) {
+            args = args.concat(['FILTER_BY_VALUE', `${options.filterByValue.min}`, `${options.filterByValue.max}`]);
+        }
         if(options?.count !== undefined){
             args = args.concat(['COUNT', `${options.count}`]);
         }
@@ -295,7 +301,7 @@ export class RedisTimeSeries extends Module {
      * @param options The 'TS.MRANGE'/'TS.MREVRANGE' command optional parameters 
      * @returns The arguments of the command
      */
-    buildMultiRangeCommand(fromTimestamp: string, toTimestamp: string, filter: string, options?: TSMRangeOptions): string[] {
+    private buildMultiRangeCommand(fromTimestamp: string, toTimestamp: string, filter: string, options?: TSMRangeOptions): string[] {
         let args = [fromTimestamp, toTimestamp];
         if(options?.count !== undefined) {
             args = args.concat(['COUNT', `${options.count}`]);
@@ -493,6 +499,10 @@ export type TSAggregationType = 'avg' | 'sum' | 'min' | 'max' | 'range' | 'range
  * The 'TS.Range' command optional parameters
  * @param align The 'ALIGN' optional parameter
  * @param count The 'COUNT' optional parameter
+ * @param filterByValue The 'FILTER_BY_VALUE' optional parameter. 
+ * @param filterByValue.min The min value to filter by
+ * @param filterByValue.max The max value to filter by`
+ * @param filterByTS The 'FILTER_BY_TS' optional parameter. A list of TS values.  
  * @param aggregation The 'AGGREGATION' optional parameter
  * @param aggregation.type The type of the 'AGGREGATION' command
  * @param aggregation.timeBucket The time bucket of the 'AGGREGATION' command
@@ -500,6 +510,11 @@ export type TSAggregationType = 'avg' | 'sum' | 'min' | 'max' | 'range' | 'range
 export type TSRangeOptions = {
     count?: number,
     align?: TSAlignType,
+    filterByValue?: {
+        min: number,
+        max: number
+    },
+    filterByTS?: string[],
     aggregation?: {
         type: TSAggregationType,
         timeBucket: number

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -119,7 +119,7 @@ describe('RediSearch Module testing', async function () {
             }
         )
     })
-     it('Simple search test with field specified in query', async () => {
+    it('Simple search test with field specified in query', async () => {
         const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
         expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command')
         expect((result[0] as {[key: string]: string}).key).to.equal('doc:1', 'first document key')

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -89,11 +89,15 @@ describe('RediSearch Module testing', async function () {
             const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
             const res = await client.search(
                 `${index}-searchtest`,
-                '@name:Brown',
+                'Brown',
                 {
                     inFields: {
                         num: 2,
-                        field: ["tags", "number"],
+                        field: ["name", "number"],
+                    },
+                    inKeys: {
+                        num: 3,
+                        field: ["alma", 2, "asad"],
                     },
                     /* highlight: {
                         tags: [{

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -129,7 +129,7 @@ describe('RediSearch Module testing', async function () {
             'Doe',
             {
                 inFields:
-                    ["age"],
+                    ['age'],
             },
         );
         expect(res).to.equal(0, 'Total number of returining document of FT.SEARCH command');
@@ -138,7 +138,7 @@ describe('RediSearch Module testing', async function () {
             'Doe',
             {
                 inFields:
-                    ["name"],
+                    ['name'],
             },
         );
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
@@ -149,7 +149,7 @@ describe('RediSearch Module testing', async function () {
             'Doe',
             {
                 inKeys:
-                    ["doc:1", "doc:2"],
+                    ['doc:1', 'doc:2'],
             },
         );
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
@@ -158,18 +158,18 @@ describe('RediSearch Module testing', async function () {
             'Doe',
             {
                 inKeys:
-                    ["doc:3"],
+                    ['doc:3'],
             },
         );
         expect(res).to.equal(0, 'Total number of returining document of FT.SEARCH command');
     });
-    it("Search tests with filter", async () => {
+    it('Search tests with filter', async () => {
         let res = await client.search(
             `${index}-searchtest`,
             '*',
             {
                 filter: [{
-                    field: "age",
+                    field: 'age',
                     min: 0,
                     max: 35,
                 }],
@@ -182,12 +182,12 @@ describe('RediSearch Module testing', async function () {
             {
                 filter: [
                     {
-                        field: "age",
+                        field: 'age',
                         min: 0,
                         max: 35,
                     },
                     {
-                        field: "salary",
+                        field: 'salary',
                         min: 0,
                         max: 2500,
                     },
@@ -196,21 +196,21 @@ describe('RediSearch Module testing', async function () {
         );
         expect(res[0]).to.equal(1, 'Total number of returining document of FT.SEARCH command');
     });
-    it("Search tests with return", async () => {
+    it('Search tests with return', async () => {
         let res = await client.search(
             `${index}-searchtest`,
             '*',
             {
                 return: [
-                    "age",
+                    'age',
                 ],
             },
         );
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command');
         expect(res[2].length).to.equal(2, 'Total number of returned key-values');
-        expect(res[2].includes("age")).to.equal(true, 'Age must be returned');
-        expect(res[2].includes("salary")).to.equal(false, 'Salary must not be returned');
-        expect(res[2].includes("name")).to.equal(false, 'Name must not be returned');
+        expect(res[2].includes('age')).to.equal(true, 'Age must be returned');
+        expect(res[2].includes('salary')).to.equal(false, 'Salary must not be returned');
+        expect(res[2].includes('name')).to.equal(false, 'Name must not be returned');
         expect(res[4].length).to.equal(2, 'Total number of returned key-values');
         expect(res[6].length).to.equal(2, 'Total number of returned key-values');
         res = await client.search(
@@ -218,14 +218,14 @@ describe('RediSearch Module testing', async function () {
             'Sarah',
             {
                 return: [
-                    "age", "salary"
+                    'age', 'salary'
                 ],
             },
         );
         expect(res[0]).to.equal(1, 'Total number of returining document of FT.SEARCH command');
-        expect(res[2].includes("age")).to.equal(true, 'Age must be returned');
-        expect(res[2].includes("salary")).to.equal(true, 'Salary must be returned');
-        expect(res[2].includes("name")).to.equal(false, 'Name must not be returned');
+        expect(res[2].includes('age')).to.equal(true, 'Age must be returned');
+        expect(res[2].includes('salary')).to.equal(true, 'Salary must be returned');
+        expect(res[2].includes('name')).to.equal(false, 'Name must not be returned');
         res = await client.search(
             `${index}-searchtest`,
             '*',
@@ -235,53 +235,53 @@ describe('RediSearch Module testing', async function () {
         );
         //BUG: { '3': 'doc:3', 'doc:2': 'doc:1' } This should return an array too, isn't it?
         //FIXME: FIX it and write tests here
-        console.warn("\x1b[31m", `RETURN 0 returns this: ${JSON.stringify(res)}`);
+        console.warn('\x1b[31m', `RETURN 0 returns this: ${JSON.stringify(res)}`);
     });
-    it("Search test with summarize", async () => {
+    it('Search test with summarize', async () => {
         let res = await client.search(
             `${index}-searchtest`,
             'De*',
             {
-                return: ["introduction"],
+                return: ['introduction'],
                 summarize: {
-                    fields: ["introduction"],
+                    fields: ['introduction'],
                     frags: 1,
                     len: 3,
-                    seperator: " !?!"
+                    seperator: ' !?!'
                 },
             },
         );
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
-        expect(res[2][1].endsWith("!?!")).to.equal(true, 'Custom summarize seperator');
-        expect(res[4][1].endsWith("!?!")).to.equal(true, 'Custom summarize seperator');
+        expect(res[2][1].endsWith('!?!')).to.equal(true, 'Custom summarize seperator');
+        expect(res[4][1].endsWith('!?!')).to.equal(true, 'Custom summarize seperator');
     });
-    it("Search tests with highlight", async () => {
+    it('Search tests with highlight', async () => {
         let res = await client.search(
             `${index}-searchtest`,
             'Do*|De*',
             {
                 highlight: {
-                    fields: ["introduction"],
+                    fields: ['introduction'],
                     tags: {
-                        open: "**",
-                        close: "**",
+                        open: '**',
+                        close: '**',
                     }
                 },
             },
         );
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
-        expect(res[2][3].includes("**")).to.equal(false, 'Name mustn\'t be highlighted');
-        expect(res[2][1].includes("**developer**")).to.equal(true, 'Introduction must be highlighted');
+        expect(res[2][3].includes('**')).to.equal(false, 'Name mustn\'t be highlighted');
+        expect(res[2][1].includes('**developer**')).to.equal(true, 'Introduction must be highlighted');
     });
-    it("Search test with sortby ", async () => {
+    it('Search test with sortby ', async () => {
         let res = await client.search(
             `${index}-searchtest`,
             '*',
             {
-                return: ["age"],
+                return: ['age'],
                 sortBy: {
-                    field: "age",
-                    sort: "ASC",
+                    field: 'age',
+                    sort: 'ASC',
                 }
             },
         );
@@ -290,7 +290,7 @@ describe('RediSearch Module testing', async function () {
         expect(res[4][1]).to.equal('30', 'Ages should be returned in ascending order');
         expect(res[6][1]).to.equal('80', 'Ages should be returned in ascending order');
     });
-    it("Search test with limit", async () => {
+    it('Search test with limit', async () => {
         let res = await client.search(
             `${index}-searchtest`,
             '*',

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -129,7 +129,7 @@ describe('RediSearch Module testing', async function () {
             'Doe',
             {
                 inFields:
-                    ['age'],
+                    ['age', 'salary'],
             },
         );
         expect(res).to.equal(0, 'Total number of returining document of FT.SEARCH command');

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -119,10 +119,10 @@ describe('RediSearch Module testing', async function () {
             }
         )
     })
-    it('Simple search test with field specified in query', async () => {
-        const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe')
+     it('Simple search test with field specified in query', async () => {
+        const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
         expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect(result[0].indexOf('doc')).to.equal(0, 'first document key')
+        expect((result[0] as {[key: string]: string}).key).to.equal('doc:1', 'first document key')
     })
     it('Simple search tests with field specified using inFields', async () => {
         let res = await client.search(
@@ -214,12 +214,12 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command')
-        expect(res[2].length).to.equal(2, 'Total number of returned key-values')
-        expect(res[2].includes('age')).to.equal(true, 'Age must be returned')
-        expect(res[2].includes('salary')).to.equal(false, 'Salary must not be returned')
-        expect(res[2].includes('name')).to.equal(false, 'Name must not be returned')
-        expect(res[4].length).to.equal(2, 'Total number of returned key-values')
-        expect(res[6].length).to.equal(2, 'Total number of returned key-values')
+        expect(Object.keys(res[1]).length).to.equal(2, 'Total number of returned key-values')
+        expect(Object.keys(res[1]).includes('age')).to.equal(true, 'Age must be returned')
+        expect(Object.keys(res[1]).includes('salary')).to.equal(false, 'Salary must not be returned')
+        expect(Object.keys(res[1]).includes('name')).to.equal(false, 'Name must not be returned')
+        expect(Object.keys(res[2]).length).to.equal(2, 'Total number of returned key-values')
+        expect(Object.keys(res[3]).length).to.equal(2, 'Total number of returned key-values')
         res = await client.search(
             `${index}-searchtest`,
             'Sarah',
@@ -237,9 +237,9 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(1, 'Total number of returining document of FT.SEARCH command')
-        expect(res[2].includes('age')).to.equal(true, 'Age must be returned')
-        expect(res[2].includes('salary')).to.equal(true, 'Salary must be returned')
-        expect(res[2].includes('name')).to.equal(false, 'Name must not be returned')
+        expect(Object.keys(res[1]).includes('age')).to.equal(true, 'Age must be returned')
+        expect(Object.keys(res[1]).includes('salary')).to.equal(true, 'Salary must be returned')
+        expect(Object.keys(res[1]).includes('name')).to.equal(false, 'Name must not be returned')
         res = await client.search(
             `${index}-searchtest`,
             '*',
@@ -266,8 +266,8 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect(res[2][1].endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
-        expect(res[4][1].endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
     })
     it('Search tests with highlight', async () => {
         const res = await client.search(
@@ -284,8 +284,8 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect(res[2][3].includes('**')).to.equal(false, 'Name mustn\'t be highlighted')
-        expect(res[2][1].includes('**developer**')).to.equal(true, 'Introduction must be highlighted')
+        expect((res[1] as {[key: string]: string}).name.includes('**')).to.equal(false, 'Name mustn\'t be highlighted')
+        expect((res[1] as {[key: string]: string}).introduction.includes('**developer**')).to.equal(true, 'Introduction must be highlighted')
     })
     it('Search test with sortby ', async () => {
         const res = await client.search(
@@ -300,9 +300,9 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command')
-        expect(res[2][1]).to.equal('25', 'Ages should be returned in ascending order')
-        expect(res[4][1]).to.equal('30', 'Ages should be returned in ascending order')
-        expect(res[6][1]).to.equal('80', 'Ages should be returned in ascending order')
+        expect((res[1] as {[key: string]: string}).age).to.equal('25', 'Ages should be returned in ascending order')
+        expect((res[2] as {[key: string]: string}).age).to.equal('30', 'Ages should be returned in ascending order')
+        expect((res[3] as {[key: string]: string}).age).to.equal('80', 'Ages should be returned in ascending order')
     })
     it('Search test with limit', async () => {
         const res = await client.search(
@@ -316,7 +316,7 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command')
-        expect(res.length).to.equal(3, 'Only one item should be returned')
+        expect(res.length).to.equal(2, 'Only one item should be returned')
     })
     it('aggregate function', async () => {
         const response = await client.aggregate(index, query)

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -61,9 +61,13 @@ describe('RediSearch Module testing', async function () {
     it('search function on JSON', async () => {
         let response = await client.search(index, query)
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
-        //FIXME: JSON Needs more tests, also I couldn't find anything related to `RETURN AS`
+        //FIXME: JSON Needs more tests, also I couldn't find anything related to `RETURN AS` so that also needs tests
+        //! Old function ran command "FT.SEARCH" "idx" "@text:name" "RETURN" "3" "$.name" "AS" "name"
+        // So implemented it in the same way
         response = await client.search(`${index}-json`, query, {
-            return: ['$.name'],
+            return: [
+                { field: '$.name', as: 'name' },
+            ],
         })
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
         await client.dropindex(`${index}-json`);
@@ -403,7 +407,9 @@ describe('RediSearch Module testing', async function () {
         expect(response.term1).to.equal('0', 'The response of the FT.SYNDUMP command');
     });
     it('spellcheck function', async () => {
-        const response = await client.spellcheck(index, query);
+        const response = await client.spellcheck(index, query, {
+            distance: 1,
+        });
         expect(response.length).to.be.greaterThan(0, 'The response of the FT.SPELLCHECK command')
     });
     it('dictadd function', async () => {

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -275,6 +275,23 @@ describe('RediSearch Module testing', async function () {
             expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
             expect(res[2][3].includes("**")).to.equal(false, 'Name mustn\'t be highlighted');
             expect(res[2][1].includes("**developer**")).to.equal(true, 'Introduction must be highlighted');
+        
+            //Search test with sortby 
+            res = await client.search(
+                `${index}-searchtest`,
+                '*',
+                {
+                    return: ["age"],
+                    sortBy: {
+                        field: "age",
+                        sort: "ASC",
+                    }
+                },
+            );
+            expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command');
+            expect(res[2][1]).to.equal('25', 'Ages should be returned in ascending order');
+            expect(res[4][1]).to.equal('30', 'Ages should be returned in ascending order');
+            expect(res[6][1]).to.equal('80', 'Ages should be returned in ascending order');
         } finally {
             await client.dropindex(`${index}-searchtest`);
         }

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -16,7 +16,7 @@ const dict = {
     name: 'dictX',
     term: 'termY'
 }
-describe('RediSearch Module testing', async function() {
+describe('RediSearch Module testing', async function () {
     before(async () => {
         client = new Redisearch({
             host: cliArguments.host,
@@ -33,7 +33,7 @@ describe('RediSearch Module testing', async function() {
         await client.disconnect();
         await redis.disconnect();
     })
-    it('create function', async () => {
+    /* it('create function', async () => {
         let response = await client.create(index, 'HASH', [{
             name: 'name',
             type: 'TEXT'
@@ -69,7 +69,7 @@ describe('RediSearch Module testing', async function() {
             }
         })
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
-    });
+    }); */
     it('search function response test', async () => {
         await client.create(`${index}-searchtest`, 'HASH', [{
             name: 'name',
@@ -82,15 +82,35 @@ describe('RediSearch Module testing', async function() {
                 }
             ]
         })
-        await client.redis.hset('doc:1', { name: 'John Doe'  });
-        await client.redis.hset('doc:2', { name: 'Jane Doe'  });
-        await client.redis.hset('doc:3', { name: 'Sarah Brown'  });
-        const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
-        await client.dropindex(`${index}-searchtest`);
-        expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect(result[0].indexOf('doc')).to.equal(0, 'first document key')
+        await client.redis.hset('doc:1', { name: 'John Doe' });
+        await client.redis.hset('doc:2', { name: 'Jane Doe' });
+        await client.redis.hset('doc:3', { name: 'Sarah Brown' });
+        try {
+            const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
+            const res = await client.search(
+                `${index}-searchtest`,
+                '@name:Brown',
+                {
+                    inFields: {
+                        num: 2,
+                        field: ["tags", "number"],
+                    },
+                    /* highlight: {
+                        tags: [{
+                            open: "<b>",
+                            close: "</b>"
+                        }],
+                    } */
+                }
+            );
+            console.log(res);
+            expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command')
+            expect(result[0].indexOf('doc')).to.equal(0, 'first document key')
+        } finally {
+            await client.dropindex(`${index}-searchtest`);
+        }
     });
-    it('aggregate function', async () => {
+    /* it('aggregate function', async () => {
         const response = await client.aggregate(index, query)
         expect(response).to.equal(0, 'The response of the FT.AGGREGATE command')
     });
@@ -232,5 +252,5 @@ describe('RediSearch Module testing', async function() {
         }])
         const response = await client.dropindex(`${index}-droptest`)
         expect(response).to.equal('OK', 'The response of the FT.DROPINDEX command');
-    });
+    }); */
 });

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -240,7 +240,7 @@ describe('RediSearch Module testing', async function () {
             //FIXME: FIX it and write tests here
             console.warn(`RETURN 0 returns this: ${JSON.stringify(res)}`);
 
-            //Search tests with summarize
+            //Search test with summarize
             res = await client.search(
                 `${index}-searchtest`,
                 'De*',
@@ -257,6 +257,24 @@ describe('RediSearch Module testing', async function () {
             expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
             expect(res[2][1].endsWith("!?!")).to.equal(true, 'Custom summarize seperator');
             expect(res[4][1].endsWith("!?!")).to.equal(true, 'Custom summarize seperator');
+
+            //Search tests with highlight
+            res = await client.search(
+                `${index}-searchtest`,
+                'Do*|De*',
+                {
+                    highlight: {
+                        fields: ["introduction"],
+                        tags: {
+                            open: "**",
+                            close: "**",
+                        }
+                    },
+                },
+            );
+            expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command');
+            expect(res[2][3].includes("**")).to.equal(false, 'Name mustn\'t be highlighted');
+            expect(res[2][1].includes("**developer**")).to.equal(true, 'Introduction must be highlighted');
         } finally {
             await client.dropindex(`${index}-searchtest`);
         }

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -30,7 +30,7 @@ describe('RediSearch Module testing', async function () {
         await redis.connect()
     })
     after(async () => {
-        await client.sendCommand("flushdb")
+        await client.redis.flushdb();
         await client.disconnect()
         await redis.disconnect()
     })

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -292,6 +292,21 @@ describe('RediSearch Module testing', async function () {
             expect(res[2][1]).to.equal('25', 'Ages should be returned in ascending order');
             expect(res[4][1]).to.equal('30', 'Ages should be returned in ascending order');
             expect(res[6][1]).to.equal('80', 'Ages should be returned in ascending order');
+
+            //Search test with limit
+            res = await client.search(
+                `${index}-searchtest`,
+                '*',
+                {
+                    limit: {
+                        first: 0,
+                        num: 1,
+                    }
+                },
+            );
+            expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command');
+            expect(res.length).to.equal(3, 'Only one item should be returned');
+            
         } finally {
             await client.dropindex(`${index}-searchtest`);
         }

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -28,13 +28,13 @@ describe('RediSearch Module testing', async function () {
         });
         await client.connect();
         await redis.connect();
-    })
+    });
     after(async () => {
         await client.dropindex(`${index}-searchtest`);
         await client.disconnect();
         await redis.disconnect();
-    })
-    /* it('create function', async () => {
+    });
+    it('create function', async () => {
         let response = await client.create(index, 'HASH', [{
             name: 'name',
             type: 'TEXT'
@@ -57,17 +57,17 @@ describe('RediSearch Module testing', async function () {
         }])
         expect(response).to.equal('OK', 'The response of the FT.CREATE command');
         await client.dropindex(`${index}1`);
-        await client.dropindex(`${index}-json`);
     });
-    it('search function', async () => {
+    it('search function on JSON', async () => {
         let response = await client.search(index, query)
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
-        response = await client.search(index, query, {
+        response = await client.search(`${index}-json`, query, {
             //FIXME: Look into this
             return: ['$.name'],
         })
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
-    }); */
+        await client.dropindex(`${index}-json`);
+    });
     it('search function response test (creation phase)', async () => {
         await client.create(`${index}-searchtest`, 'HASH', [{
             name: 'name',
@@ -119,7 +119,7 @@ describe('RediSearch Module testing', async function () {
         );
     });
     it('Simple search test with field specified in query', async () => {
-        let [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
+        const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
         expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command');
         expect(result[0].indexOf('doc')).to.equal(0, 'first document key');
     });
@@ -238,7 +238,7 @@ describe('RediSearch Module testing', async function () {
         console.warn('\x1b[31m', `RETURN 0 returns this: ${JSON.stringify(res)}`);
     });
     it('Search test with summarize', async () => {
-        let res = await client.search(
+        const res = await client.search(
             `${index}-searchtest`,
             'De*',
             {
@@ -256,7 +256,7 @@ describe('RediSearch Module testing', async function () {
         expect(res[4][1].endsWith('!?!')).to.equal(true, 'Custom summarize seperator');
     });
     it('Search tests with highlight', async () => {
-        let res = await client.search(
+        const res = await client.search(
             `${index}-searchtest`,
             'Do*|De*',
             {
@@ -274,7 +274,7 @@ describe('RediSearch Module testing', async function () {
         expect(res[2][1].includes('**developer**')).to.equal(true, 'Introduction must be highlighted');
     });
     it('Search test with sortby ', async () => {
-        let res = await client.search(
+        const res = await client.search(
             `${index}-searchtest`,
             '*',
             {
@@ -291,7 +291,7 @@ describe('RediSearch Module testing', async function () {
         expect(res[6][1]).to.equal('80', 'Ages should be returned in ascending order');
     });
     it('Search test with limit', async () => {
-        let res = await client.search(
+        const res = await client.search(
             `${index}-searchtest`,
             '*',
             {

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -61,8 +61,8 @@ describe('RediSearch Module testing', async function () {
     it('search function on JSON', async () => {
         let response = await client.search(index, query)
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
+        //FIXME: Needs more tests, also I couldn't find anything related to `RETURN AS`
         response = await client.search(`${index}-json`, query, {
-            //FIXME: Look into this
             return: ['$.name'],
         })
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
@@ -244,7 +244,9 @@ describe('RediSearch Module testing', async function () {
             {
                 return: ['introduction'],
                 summarize: {
-                    fields: ['introduction'],
+                    /* fields: ['introduction'], */ 
+                    //! specifying fields in summarize while return is also specified will cause redis (edge version) to crash
+                    //! Crash in redis image fabe0b38e273
                     frags: 1,
                     len: 3,
                     seperator: ' !?!'
@@ -304,7 +306,7 @@ describe('RediSearch Module testing', async function () {
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command');
         expect(res.length).to.equal(3, 'Only one item should be returned');
     });
-    /* it('aggregate function', async () => {
+    it('aggregate function', async () => {
         const response = await client.aggregate(index, query)
         expect(response).to.equal(0, 'The response of the FT.AGGREGATE command')
     });
@@ -446,5 +448,5 @@ describe('RediSearch Module testing', async function () {
         }])
         const response = await client.dropindex(`${index}-droptest`)
         expect(response).to.equal('OK', 'The response of the FT.DROPINDEX command');
-    }); */
+    });
 });

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -82,12 +82,7 @@ describe('RediSearch Module testing', async function () {
             name: 'introduction',
             type: 'TEXT'
         }], {
-            prefix: [
-                {
-                    count: 1,
-                    name: 'doc'
-                }
-            ]
+            prefix: ["doc"],
         })
 
         await client.redis.hset(
@@ -327,12 +322,7 @@ describe('RediSearch Module testing', async function () {
             sortable: true
         }
         ], {
-            prefix: [
-                {
-                    count: 1,
-                    name: 'person'
-                }
-            ]
+            prefix: ['person']
         });
 
         const time = new Date();

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -62,12 +62,13 @@ describe('RediSearch Module testing', async function () {
         let response = await client.search(index, query)
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
         //FIXME: JSON Needs more tests, also I couldn't find anything related to `RETURN AS` so that also needs tests
-        //! Old function ran command "FT.SEARCH" "idx" "@text:name" "RETURN" "3" "$.name" "AS" "name"
-        // So implemented it in the same way
         response = await client.search(`${index}-json`, query, {
-            return: [
-                { field: '$.name', as: 'name' }
-            ],
+            return: {
+                num: 3,
+                fields: [
+                    { field: '$.name', as: 'name' }
+                ]
+            }
         })
         expect(response).to.equal(0, 'The response of the FT.SEARCH command')
         await client.dropindex(`${index}-json`)
@@ -86,7 +87,9 @@ describe('RediSearch Module testing', async function () {
             name: 'introduction',
             type: 'TEXT'
         }], {
-            prefix: ["doc"]
+            prefix: {
+                prefixes: ["doc", "alma"]
+            }
         })
         await client.redis.hset(
             'doc:1',
@@ -126,7 +129,9 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             'Doe',
             {
-                inFields: ['age', 'salary']
+                inFields: {
+                    fields: ['age', 'salary']
+                }
             }
         )
         expect(res).to.equal(0, 'Total number of returining document of FT.SEARCH command')
@@ -134,7 +139,9 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             'Doe',
             {
-                inFields: ['name']
+                inFields: {
+                    fields: ['name']
+                }
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
@@ -144,7 +151,9 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             'Doe',
             {
-                inKeys: ['doc:1', 'doc:2']
+                inKeys: {
+                    keys: ['doc:1', 'doc:2']
+                }
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
@@ -152,7 +161,9 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             'Doe',
             {
-                inKeys: ['doc:3']
+                inKeys: {
+                    keys: ['doc:3']
+                }
             }
         )
         expect(res).to.equal(0, 'Total number of returining document of FT.SEARCH command')
@@ -195,7 +206,11 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             '*',
             {
-                return: ['age']
+                return: {
+                    fields: [{
+                        field: 'age',
+                    }]
+                }
             }
         )
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command')
@@ -209,7 +224,16 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             'Sarah',
             {
-                return: ['age', 'salary']
+                return: {
+                    fields: [
+                        {
+                            field: 'age',
+                        },
+                        {
+                            field: 'salary',
+                        }
+                    ]
+                }
             }
         )
         expect(res[0]).to.equal(1, 'Total number of returining document of FT.SEARCH command')
@@ -220,7 +244,7 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             '*',
             {
-                return: []
+                return: { fields: [] }
             }
         )
         expect(res.length).to.equal(4, 'Only keys should be returned (+count of them)')
@@ -234,7 +258,7 @@ describe('RediSearch Module testing', async function () {
                 //! Crash in redis image fabe0b38e273
                 // return: ['introduction'],
                 summarize: {
-                    fields: ['introduction'],
+                    fields: { fields: ['introduction'] },
                     frags: 1,
                     len: 3,
                     seperator: ' !?!'
@@ -251,7 +275,7 @@ describe('RediSearch Module testing', async function () {
             'Do*|De*',
             {
                 highlight: {
-                    fields: ['introduction'],
+                    fields: { fields: ['introduction'] },
                     tags: {
                         open: '**',
                         close: '**'
@@ -268,7 +292,7 @@ describe('RediSearch Module testing', async function () {
             `${index}-searchtest`,
             '*',
             {
-                return: ['age'],
+                return: { fields: [{ field: 'age' }] },
                 sortBy: {
                     field: 'age',
                     sort: 'ASC'
@@ -317,7 +341,7 @@ describe('RediSearch Module testing', async function () {
             sortable: true
         }
         ], {
-            prefix: ['person']
+            prefix: {prefixes: ['person']}
         })
 
         const time = new Date()

--- a/tests/rts.ts
+++ b/tests/rts.ts
@@ -86,12 +86,28 @@ describe('RTS Module testing', async function() {
     });
     it('range function', async () => {
         const data = await client.get(key1);
-        const response = await client.range(key1, data[0].toString(), data[1].toString())
+        let response = await client.range(key1, data[0].toString(), data[1].toString())
+        expect(response.length).to.equal(0, 'The range items length of the response')
+        response = await client.range(key1, `${data[0]}`, `${data[1]}`, {
+            align: 'start',
+            aggregation: {
+                type: 'count',
+                timeBucket: 10
+            }
+        });
         expect(response.length).to.equal(0, 'The range items length of the response')
     });
     it('revrange function', async () => {
         const data = await client.get(key1);
-        const response = await client.revrange(key1, data[0].toString(), data[1].toString())
+        let response = await client.revrange(key1, data[0].toString(), data[1].toString())
+        expect(response.length).to.equal(0, 'The range items length of the response')
+        response = await client.revrange(key1, `${data[0]}`, `${data[1]}`, {
+            align: 'start',
+            aggregation: {
+                type: 'count',
+                timeBucket: 10
+            }
+        });
         expect(response.length).to.equal(0, 'The range items length of the response')
     });
     it('mrange function', async () => {
@@ -119,7 +135,15 @@ describe('RTS Module testing', async function() {
     });
     it('mrevrange function', async () => {
         const info = await client.info(key1);
-        const response = await client.mrevrange((info.firstTimestamp-1).toString(), (info.lastTimestamp+10000).toString(), 'label=value')
+        let response = await client.mrevrange((info.firstTimestamp-1).toString(), (info.lastTimestamp+10000).toString(), 'label=value')
+        expect(response[0][0]).to.equal('key:2:32', 'The filtered key name');
+        response = await client.mrevrange(`${info.firstTimestamp-1}`, `${info.lastTimestamp+10000}`, 'label=value', {
+            align: '+',
+            aggregation: {
+                type: 'count',
+                timeBucket: 10
+            }
+        })
         expect(response[0][0]).to.equal('key:2:32', 'The filtered key name');
     });
     it('get function', async () => {

--- a/tests/rts.ts
+++ b/tests/rts.ts
@@ -96,8 +96,26 @@ describe('RTS Module testing', async function() {
     });
     it('mrange function', async () => {
         const info = await client.info(key1);
-        const response = await client.mrange((info.firstTimestamp-1).toString(), (info.lastTimestamp+10000).toString(), 'label=value')
-        expect(response[0][0]).to.equal('key:2:32', 'The filtered key name');
+        const fromTimestamp = (info.firstTimestamp-1);
+        const toTimestamp = (info.lastTimestamp+10000);
+        const key = 'key:2:32';
+        const filter = 'label=value';
+        let response = await client.mrange(`${fromTimestamp}`, `${toTimestamp}`, filter);
+        expect(response[0][0]).to.equal(key, 'The filtered key name');
+        response = await client.mrange(`${fromTimestamp}`, `${toTimestamp}`, filter, {
+            groupBy: {
+                label: 'label',
+                reducer: 'MAX'
+            },
+            withLabels: true
+        });
+        expect(response[0][0]).to.equal(filter, 'The value of the filter');
+        expect(response[0][1][0][0]).to.equal('label', 'The name of the label');
+        expect(response[0][1][0][1]).to.equal('value', 'The value of the label value');
+        expect(response[0][1][1][0]).to.equal('__reducer__', 'The key of the reducer');
+        expect(response[0][1][1][1]).to.equal('max', 'The value of the reducer');
+        expect(response[0][1][2][0]).to.equal('__source__', 'The key of the source');
+        expect(response[0][1][2][1]).to.equal(key, 'The value of the source');
     });
     it('mrevrange function', async () => {
         const info = await client.info(key1);


### PR DESCRIPTION
# Fix for #125 and also some other stuff

- Fixes `prefix` on FT.CREATE
- Fixes `stopwords` on FT.CREATE
- Fixes `bool !== undefined` to `bool === true`
- Added `UNF` and `CASESENSITIVE`
- Fixes `VERBATIM` on  FT.SEARCH
- Fixes `filter` on FT.SEARCH
- Fixes `inkeys` and `infields` on FT.SEARCH
- Fixes `return` on FT.SEARCH
- Fixes `summarize` on FT.SEARCH
- Fixes `highlight` on FT.SEARCH
- Wrote more tests for redisearch
- Rewrote documentation according to JSDoc specification
- Fix parser trying to parse search response to object

## BREAKING CHANGES
These variable/object types reflect the original redis syntax better
#### On `FTCreateParameters`:
`prefix` and `stopwords` changed from
```
prefix?: {	
        count: number,	
        name: string	
}[],
stopwords?: {	
        num: number,	
        stopword: string
}[],
```
to
```
prefix?: string[],
stopwords?: string[],
```
---
#### On `FTSearchParameters`:
`filter`, `inkeys`, `infields`, `return`, `summarize` and `highlight` changed from
```
filter?: {	
        field: string,	
        min: number,	
        max: number	
},
inKeys?: {	
        num: number,	
        field: string	
},
inFields?: {	
        num: number,	
        field: string	
},
return?: {	
        num: number,	
        fields?: {	
            name: string,	
            as?: string	
        }[]	
},
summarize?: {	
        fields?: {	
            num: number,	
            field: string	
        }[],	
        frags?: number,	
        len?: number,	
        seperator?: string	
},	
highlight?: {	
        fields?: {	
            num: number,	
            field: string	
        }[],	
        tags?: {	
            open: string,	
            close: string	
        }[]	
},
```
to
```
filter?: {
        field: string,
        min: number,
        max: number
}[],
inKeys?: (string | number)[],
inFields?: (string | number)[],
return?: (string | {
        field: string,
        as?: string,
})[],
summarize?: {
        fields?: string[],
        frags?: number,
        len?: number,
        seperator?: string
},
highlight?: {
        fields?: string[],
        tags?: {
            open: string,
            close: string
        },
},
```
---
#### On `FTSugAddParameters`:
```
incr: number,
```
to
```
incr: boolean,
```
---
#### On `FTSugGetParameters`:
```
fuzzy: string,
```
to
```
fuzzy: boolean,
```
---
#### On `FTSpellCheck` (not so breaking):
```
distance?: string
```
to
```
distance?: number | string,
```
---

JUST A LITTLE NOTE HERE:
I couldn't find anything about the JSON index type and the `AS` parameter so I couldn't write tests to check whether they were implemented correctly.

Like the original filter code executes this query, so does my changed code:
```
"FT.SEARCH" "idx" "@text:name" "RETURN" "3" "$.name" "AS" "name"
```
But I have a feeling it should look like this (But this throws an error)
```
"FT.SEARCH" "idx" "@text:name" "RETURN" "1" "$.name" "AS" "name"
```