### PR TITLE
[RediSearch] Fix num parameter and spellcheck response object

### DIFF
--- a/modules/redis-modules.ts
+++ b/modules/redis-modules.ts
@@ -27,6 +27,7 @@ import { GearsCommander } from './redisgears/redisgears.commander';
 import { GraphCommander } from './redisgraph/redisgraph.commander';
 import { RejsonCommander } from './rejson/rejson.commander';
 import { RedisTimeSeriesCommander } from './rts/rts.commander';
+import { RedisearchHelpers } from './redisearch/redisearch.helpers';
 
 export class RedisModules extends Module {
 	public bloomCommander = new BloomCommander()
@@ -41,6 +42,7 @@ export class RedisModules extends Module {
 	public rejsonCommander = new RejsonCommander()
 	public risCommander = new RedisIntervalSetsCommander()
 	public rtsCommander = new RedisTimeSeriesCommander()
+	public searchHelpers = new RedisearchHelpers();
 
 	/**
      * Initializing the module object

--- a/modules/redisearch/redisearch.commander.ts
+++ b/modules/redisearch/redisearch.commander.ts
@@ -19,11 +19,15 @@ export class SearchCommander {
         if(parameters !== undefined) {
             if(parameters.prefix !== undefined) {
                 args.push('PREFIX')
-                args.push(
-                    parameters.prefix.num !== undefined ?
-                        `${parameters.prefix.num}` :
-                        `${parameters.prefix.prefixes.length}`
-                )
+                if(parameters.prefix.num !== undefined) {
+                    args.push(`${parameters.prefix.num}`)
+                } else {
+                    if(Array.isArray(parameters.prefix.prefixes)) {
+                        args.push(`${parameters.prefix.prefixes.length}`)
+                    } else {
+                        args.push("1")
+                    }
+                }
                 args = args.concat(parameters.prefix.prefixes);
             }
             if(parameters.filter !== undefined)
@@ -52,11 +56,15 @@ export class SearchCommander {
                 args.push('NOFREQS')
             if(parameters.stopwords !== undefined) {
                 args.push('STOPWORDS')
-                args.push(
-                    parameters.stopwords.num !== undefined ?
-                        `${parameters.stopwords.num}` :
-                        `${parameters.stopwords.stopwords.length}`
-                )
+                if(parameters.stopwords.num !== undefined) {
+                    args.push(`${parameters.stopwords.num}`)
+                } else {
+                    if(Array.isArray(parameters.stopwords.stopwords)) {
+                        args.push(`${parameters.stopwords.stopwords.length}`)
+                    } else {
+                        args.push("1")
+                    }
+                }
                 args = args.concat(parameters.stopwords.stopwords);
             }
             if(parameters.skipInitialScan === true)
@@ -119,20 +127,32 @@ export class SearchCommander {
                     `${parameters.geoFilter.radius}`,
                     parameters.geoFilter.measurement
                 ])
-            if(parameters.inKeys !== undefined)
-                args = args.concat([
-                    'INKEYS',
-                    parameters.inKeys.num !== undefined ?
-                        `${parameters.inKeys.num}` :
-                        `${parameters.inKeys.keys.length}`,
-                ]).concat(parameters.inKeys.keys);
-            if(parameters.inFields !== undefined)
-                args = args.concat([
-                    'INFIELDS',
-                    parameters.inFields.num !== undefined ?
-                        `${parameters.inFields.num}` :
-                        `${parameters.inFields.fields.length}`,
-                ]).concat(parameters.inFields.fields);
+            if(parameters.inKeys !== undefined) {
+                args.push('INKEYS')
+                if(parameters.inKeys.num !== undefined) {
+                    args.push(`${parameters.inKeys.num}`)
+                } else {
+                    if(Array.isArray(parameters.inKeys.keys)) {
+                        args.push(`${parameters.inKeys.keys.length}`)
+                    } else {
+                        args.push("1")
+                    }
+                }
+                args = args.concat(parameters.inKeys.keys);
+            }
+            if(parameters.inFields !== undefined) {
+                args.push('INFIELDS');
+                if(parameters.inFields.num !== undefined) {
+                    args.push(`${parameters.inFields.num}`)
+                } else {
+                    if(Array.isArray(parameters.inFields.fields)) {
+                        args.push(`${parameters.inFields.fields.length}`)
+                    } else {
+                        args.push("1")
+                    }
+                }
+                args = args.concat(parameters.inFields.fields);
+            }
             if(parameters.return !== undefined) {
                 args = args.concat([
                     'RETURN',
@@ -154,11 +174,15 @@ export class SearchCommander {
                 args.push('SUMMARIZE')
                 if(parameters.summarize.fields !== undefined) {
                     args.push('FIELDS')
-                    args.push(
-                        parameters.summarize.fields.num !== undefined ?
-                            `${parameters.summarize.fields.num}` :
-                            `${parameters.summarize.fields.fields.length}`
-                    )
+                    if(parameters.summarize.fields.num !== undefined) {
+                        args.push(`${parameters.summarize.fields.num}`)
+                    } else {
+                        if(Array.isArray(parameters.summarize.fields.fields)) {
+                            args.push(`${parameters.summarize.fields.fields.length}`)
+                        } else {
+                            args.push("1")
+                        }
+                    }
                     args = args.concat(parameters.summarize.fields.fields)
                 }
                 if(parameters.summarize.frags !== undefined)
@@ -171,12 +195,17 @@ export class SearchCommander {
             if(parameters.highlight !== undefined) {
                 args.push('HIGHLIGHT')
                 if(parameters.highlight.fields !== undefined) {
-                    args = args.concat([
-                        'FIELDS',
-                        parameters.highlight.fields.num !== undefined ?
-                            `${parameters.highlight.fields.num}` :
-                            `${parameters.highlight.fields.fields.length}`,
-                    ]).concat(parameters.highlight.fields.fields);
+                    args.push('FIELDS');
+                    if(parameters.highlight.fields.num !== undefined) {
+                        args.push(`${parameters.highlight.fields.num}`)
+                    } else {
+                        if(Array.isArray(parameters.highlight.fields.fields)) {
+                            args.push(`${parameters.highlight.fields.fields.length}`)
+                        } else {
+                            args.push("1")
+                        }
+                    }
+                    args = args.concat(parameters.highlight.fields.fields);
                 }
                 if(parameters.highlight.tags !== undefined) {
                     args.push('TAGS')

--- a/modules/redisearch/redisearch.commander.ts
+++ b/modules/redisearch/redisearch.commander.ts
@@ -21,12 +21,10 @@ export class SearchCommander {
                 args.push('PREFIX')
                 if(parameters.prefix.num !== undefined) {
                     args.push(`${parameters.prefix.num}`)
+                } else if(Array.isArray(parameters.prefix.prefixes)) {
+                    args.push(`${parameters.prefix.prefixes.length}`)
                 } else {
-                    if(Array.isArray(parameters.prefix.prefixes)) {
-                        args.push(`${parameters.prefix.prefixes.length}`)
-                    } else {
-                        args.push("1")
-                    }
+                    args.push("1")
                 }
                 args = args.concat(parameters.prefix.prefixes);
             }
@@ -58,12 +56,10 @@ export class SearchCommander {
                 args.push('STOPWORDS')
                 if(parameters.stopwords.num !== undefined) {
                     args.push(`${parameters.stopwords.num}`)
+                } else if(Array.isArray(parameters.stopwords.stopwords)) {
+                    args.push(`${parameters.stopwords.stopwords.length}`)
                 } else {
-                    if(Array.isArray(parameters.stopwords.stopwords)) {
-                        args.push(`${parameters.stopwords.stopwords.length}`)
-                    } else {
-                        args.push("1")
-                    }
+                    args.push("1")
                 }
                 args = args.concat(parameters.stopwords.stopwords);
             }
@@ -131,12 +127,10 @@ export class SearchCommander {
                 args.push('INKEYS')
                 if(parameters.inKeys.num !== undefined) {
                     args.push(`${parameters.inKeys.num}`)
+                } else if(Array.isArray(parameters.inKeys.keys)) {
+                    args.push(`${parameters.inKeys.keys.length}`)
                 } else {
-                    if(Array.isArray(parameters.inKeys.keys)) {
-                        args.push(`${parameters.inKeys.keys.length}`)
-                    } else {
-                        args.push("1")
-                    }
+                    args.push("1")
                 }
                 args = args.concat(parameters.inKeys.keys);
             }
@@ -144,12 +138,10 @@ export class SearchCommander {
                 args.push('INFIELDS');
                 if(parameters.inFields.num !== undefined) {
                     args.push(`${parameters.inFields.num}`)
+                } else if(Array.isArray(parameters.inFields.fields)) {
+                    args.push(`${parameters.inFields.fields.length}`)
                 } else {
-                    if(Array.isArray(parameters.inFields.fields)) {
-                        args.push(`${parameters.inFields.fields.length}`)
-                    } else {
-                        args.push("1")
-                    }
+                    args.push("1")
                 }
                 args = args.concat(parameters.inFields.fields);
             }
@@ -176,12 +168,10 @@ export class SearchCommander {
                     args.push('FIELDS')
                     if(parameters.summarize.fields.num !== undefined) {
                         args.push(`${parameters.summarize.fields.num}`)
+                    } else if(Array.isArray(parameters.summarize.fields.fields)) {
+                        args.push(`${parameters.summarize.fields.fields.length}`)
                     } else {
-                        if(Array.isArray(parameters.summarize.fields.fields)) {
-                            args.push(`${parameters.summarize.fields.fields.length}`)
-                        } else {
-                            args.push("1")
-                        }
+                        args.push("1")
                     }
                     args = args.concat(parameters.summarize.fields.fields)
                 }
@@ -198,12 +188,10 @@ export class SearchCommander {
                     args.push('FIELDS');
                     if(parameters.highlight.fields.num !== undefined) {
                         args.push(`${parameters.highlight.fields.num}`)
+                    } else if(Array.isArray(parameters.highlight.fields.fields)) {
+                        args.push(`${parameters.highlight.fields.fields.length}`)
                     } else {
-                        if(Array.isArray(parameters.highlight.fields.fields)) {
-                            args.push(`${parameters.highlight.fields.fields.length}`)
-                        } else {
-                            args.push("1")
-                        }
+                        args.push("1")
                     }
                     args = args.concat(parameters.highlight.fields.fields);
                 }

--- a/modules/redisearch/redisearch.helpers.ts
+++ b/modules/redisearch/redisearch.helpers.ts
@@ -1,0 +1,25 @@
+import { FTSpellCheckResponse } from "./redisearch.types";
+
+export class RedisearchHelpers {
+    /**
+     * Parses `spellcheck` response into a list of objects.
+     * @param response The response array from the spellcheck command
+     */
+    handleSpellcheckResponse(response: any): FTSpellCheckResponse[] {
+        const output = [];
+        for(const term of response) {
+            output.push({
+                term: term[1],
+                suggestions: (term[2] as string[]).map(
+                    function (suggestionArrayElem) {
+                        return {
+                            score: suggestionArrayElem[0],
+                            suggestion: suggestionArrayElem[1]
+                        }
+                    }
+                )
+            });
+        }
+        return output;
+    }
+}

--- a/modules/redisearch/redisearch.ts
+++ b/modules/redisearch/redisearch.ts
@@ -254,6 +254,7 @@ export class Redisearch extends Module {
     async spellcheck(index: string, query: string, options?: FTSpellCheck): Promise<string[]> {
         const command = this.searchCommander.spellcheck(index, query, options);
         const response = await this.sendCommand(command);
+        console.log(response);
         return this.handleResponse(response);
     }
 

--- a/modules/redisearch/redisearch.ts
+++ b/modules/redisearch/redisearch.ts
@@ -6,10 +6,13 @@ import {
     FTAggregateParameters, FTConfig, FTCreateParameters, FTFieldOptions, FTFieldType, FTIndexType, FTInfo, FTSchemaField,
     FTSearchParameters, FTSpellCheck, FTSpellCheckResponse, FTSugAddParameters, FTSugGetParameters
 } from './redisearch.types';
+import { RedisearchHelpers } from './redisearch.helpers';
 
 export class Redisearch extends Module {
 
     private searchCommander = new SearchCommander();
+    private helpers = new RedisearchHelpers();
+
     /**
      * Initializing the module object
      * @param name The name of the module
@@ -254,29 +257,7 @@ export class Redisearch extends Module {
     async spellcheck(index: string, query: string, options?: FTSpellCheck): Promise<FTSpellCheckResponse[]> {
         const command = this.searchCommander.spellcheck(index, query, options);
         const response = await this.sendCommand(command);
-        return this.handleSpellcheckResponse(response);
-    }
-
-    /**
-     * Parses `spellcheck` response into a list of objects.
-     * @param response The response array from the spellcheck command
-     */
-    handleSpellcheckResponse(response: any): FTSpellCheckResponse[] {
-        const output = [];
-        for(const term of response){
-            output.push({
-                term: term[1],
-                suggestions: (term[2] as string[]).map(
-                    function (suggestionArrayElem) {
-                        return {
-                            score: suggestionArrayElem[0],
-                            suggestion: suggestionArrayElem[1]
-                        }
-                    }
-                )
-            });
-        }
-        return output;
+        return this.helpers.handleSpellcheckResponse(response);
     }
 
     /**

--- a/modules/redisearch/redisearch.ts
+++ b/modules/redisearch/redisearch.ts
@@ -257,6 +257,10 @@ export class Redisearch extends Module {
         return this.handleSpellcheckResponse(response);
     }
 
+    /**
+     * Parses `spellcheck` response into a list of objects.
+     * @param response The response array from the spellcheck command
+     */
     handleSpellcheckResponse(response: any): FTSpellCheckResponse[] {
         const output = [];
         for(const term of response){

--- a/modules/redisearch/redisearch.ts
+++ b/modules/redisearch/redisearch.ts
@@ -11,7 +11,7 @@ import { RedisearchHelpers } from './redisearch.helpers';
 export class Redisearch extends Module {
 
     private searchCommander = new SearchCommander();
-    private helpers = new RedisearchHelpers();
+    private searchHelpers = new RedisearchHelpers();
 
     /**
      * Initializing the module object
@@ -257,7 +257,7 @@ export class Redisearch extends Module {
     async spellcheck(index: string, query: string, options?: FTSpellCheck): Promise<FTSpellCheckResponse[]> {
         const command = this.searchCommander.spellcheck(index, query, options);
         const response = await this.sendCommand(command);
-        return this.helpers.handleSpellcheckResponse(response);
+        return this.searchHelpers.handleSpellcheckResponse(response);
     }
 
     /**

--- a/modules/redisearch/redisearch.types.ts
+++ b/modules/redisearch/redisearch.types.ts
@@ -626,3 +626,26 @@ export interface FTInfo {
         index_total?: number
     }
 }
+
+/**
+ * The FT.SPELLCHECK response object
+ */
+export interface FTSpellCheckResponse {
+    /** 
+     * The term that was spellchecked
+    */
+    term: string,
+    /**
+     *  Suggested corrections
+     */
+    suggestions: {
+        /**
+         * Score of the suggestion
+         */
+        score: string,
+        /**
+         * Score of the suggestion
+         */
+        suggestion: string
+    }[],
+}

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -34,7 +34,7 @@ describe('RediSearch Module testing', async function () {
         await client.disconnect()
         await redis.disconnect()
     })
-    /* it('create function', async () => {
+    it('create function', async () => {
         let response = await client.create(index, 'HASH', [{
             name: 'name',
             type: 'TEXT'
@@ -420,7 +420,7 @@ describe('RediSearch Module testing', async function () {
     it('syndump function', async () => {
         const response = await client.syndump(index)
         expect(response.term1).to.equal('0', 'The response of the FT.SYNDUMP command')
-    }) */
+    })
     it('spellcheck function', async () => {
         await client.create(`${index}-spellcheck`, 'HASH', [{
             name: "content",
@@ -436,7 +436,7 @@ describe('RediSearch Module testing', async function () {
         response = await client.spellcheck(`${index}-spellcheck`, "mellow blua")
         expect(response.length).to.equal(2, 'Both word should be spellchecked')
     })
-    /* it('dictadd function', async () => {
+    it('dictadd function', async () => {
         const response = await client.dictadd(dict.name, [dict.term])
         expect(response).to.equal(1, 'The response of the FT.DICTADD command')
     })
@@ -466,5 +466,5 @@ describe('RediSearch Module testing', async function () {
         }])
         const response = await client.dropindex(`${index}-droptest`)
         expect(response).to.equal('OK', 'The response of the FT.DROPINDEX command')
-    }) */
+    })
 })

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -423,16 +423,18 @@ describe('RediSearch Module testing', async function () {
     }) */
     it('spellcheck function', async () => {
         await client.create(`${index}-spellcheck`, 'HASH', [{
-            name: "colors",
+            name: "content",
             type: "TEXT",
         }], {
             prefix: { prefixes: 'colors:' }
         });
-        await client.redis.hset('colors:1', { colors: 'red green blue yellow' });
+        await client.redis.hset('colors:1', { content: 'red green blue yellow mellon' })
 
-        const response = await client.spellcheck(index, "mellow");
-        console.log(response);
-        expect(response.length).to.be.greaterThan(0, 'The response of the FT.SPELLCHECK command')
+        let response = await client.spellcheck(`${index}-spellcheck`, "redis")
+        expect(response[0].suggestions.length).to.equal(0, 'No suggestion should be found')
+
+        response = await client.spellcheck(`${index}-spellcheck`, "mellow blua")
+        expect(response.length).to.equal(2, 'Both word should be spellchecked')
     })
     /* it('dictadd function', async () => {
         const response = await client.dictadd(dict.name, [dict.term])

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -122,7 +122,7 @@ describe('RediSearch Module testing', async function () {
     it('Simple search test with field specified in query', async () => {
         const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
         expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((result[0] as { [key: string]: string }).key).to.equal('doc:1', 'first document key')
+        expect((result[0] as {[key: string]: string}).key).to.equal('doc:1', 'first document key')
     })
     it('Simple search tests with field specified using inFields', async () => {
         let res = await client.search(
@@ -266,8 +266,8 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as { [key: string]: string }).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
-        expect((res[1] as { [key: string]: string }).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
     })
     it('Search tests with highlight', async () => {
         const res = await client.search(
@@ -284,8 +284,8 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as { [key: string]: string }).name.includes('**')).to.equal(false, 'Name mustn\'t be highlighted')
-        expect((res[1] as { [key: string]: string }).introduction.includes('**developer**')).to.equal(true, 'Introduction must be highlighted')
+        expect((res[1] as {[key: string]: string}).name.includes('**')).to.equal(false, 'Name mustn\'t be highlighted')
+        expect((res[1] as {[key: string]: string}).introduction.includes('**developer**')).to.equal(true, 'Introduction must be highlighted')
     })
     it('Search test with sortby ', async () => {
         const res = await client.search(
@@ -300,9 +300,9 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as { [key: string]: string }).age).to.equal('25', 'Ages should be returned in ascending order')
-        expect((res[2] as { [key: string]: string }).age).to.equal('30', 'Ages should be returned in ascending order')
-        expect((res[3] as { [key: string]: string }).age).to.equal('80', 'Ages should be returned in ascending order')
+        expect((res[1] as {[key: string]: string}).age).to.equal('25', 'Ages should be returned in ascending order')
+        expect((res[2] as {[key: string]: string}).age).to.equal('30', 'Ages should be returned in ascending order')
+        expect((res[3] as {[key: string]: string}).age).to.equal('80', 'Ages should be returned in ascending order')
     })
     it('Search test with limit', async () => {
         const res = await client.search(
@@ -341,7 +341,7 @@ describe('RediSearch Module testing', async function () {
             sortable: true
         }
         ], {
-            prefix: { prefixes: ['person'] }
+            prefix: {prefixes: ['person']}
         })
 
         const time = new Date()

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -34,7 +34,7 @@ describe('RediSearch Module testing', async function () {
         await client.disconnect()
         await redis.disconnect()
     })
-    it('create function', async () => {
+    /* it('create function', async () => {
         let response = await client.create(index, 'HASH', [{
             name: 'name',
             type: 'TEXT'
@@ -122,7 +122,7 @@ describe('RediSearch Module testing', async function () {
     it('Simple search test with field specified in query', async () => {
         const [count, ...result] = await client.search(`${index}-searchtest`, '@name:Doe');
         expect(count).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((result[0] as {[key: string]: string}).key).to.equal('doc:1', 'first document key')
+        expect((result[0] as { [key: string]: string }).key).to.equal('doc:1', 'first document key')
     })
     it('Simple search tests with field specified using inFields', async () => {
         let res = await client.search(
@@ -266,8 +266,8 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
-        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as { [key: string]: string }).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as { [key: string]: string }).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
     })
     it('Search tests with highlight', async () => {
         const res = await client.search(
@@ -284,8 +284,8 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as {[key: string]: string}).name.includes('**')).to.equal(false, 'Name mustn\'t be highlighted')
-        expect((res[1] as {[key: string]: string}).introduction.includes('**developer**')).to.equal(true, 'Introduction must be highlighted')
+        expect((res[1] as { [key: string]: string }).name.includes('**')).to.equal(false, 'Name mustn\'t be highlighted')
+        expect((res[1] as { [key: string]: string }).introduction.includes('**developer**')).to.equal(true, 'Introduction must be highlighted')
     })
     it('Search test with sortby ', async () => {
         const res = await client.search(
@@ -300,9 +300,9 @@ describe('RediSearch Module testing', async function () {
             }
         )
         expect(res[0]).to.equal(3, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as {[key: string]: string}).age).to.equal('25', 'Ages should be returned in ascending order')
-        expect((res[2] as {[key: string]: string}).age).to.equal('30', 'Ages should be returned in ascending order')
-        expect((res[3] as {[key: string]: string}).age).to.equal('80', 'Ages should be returned in ascending order')
+        expect((res[1] as { [key: string]: string }).age).to.equal('25', 'Ages should be returned in ascending order')
+        expect((res[2] as { [key: string]: string }).age).to.equal('30', 'Ages should be returned in ascending order')
+        expect((res[3] as { [key: string]: string }).age).to.equal('80', 'Ages should be returned in ascending order')
     })
     it('Search test with limit', async () => {
         const res = await client.search(
@@ -341,7 +341,7 @@ describe('RediSearch Module testing', async function () {
             sortable: true
         }
         ], {
-            prefix: {prefixes: ['person']}
+            prefix: { prefixes: ['person'] }
         })
 
         const time = new Date()
@@ -420,14 +420,21 @@ describe('RediSearch Module testing', async function () {
     it('syndump function', async () => {
         const response = await client.syndump(index)
         expect(response.term1).to.equal('0', 'The response of the FT.SYNDUMP command')
-    })
+    }) */
     it('spellcheck function', async () => {
-        const response = await client.spellcheck(index, query, {
-            distance: 1
-        })
+        await client.create(`${index}-spellcheck`, 'HASH', [{
+            name: "colors",
+            type: "TEXT",
+        }], {
+            prefix: { prefixes: 'colors:' }
+        });
+        await client.redis.hset('colors:1', { colors: 'red green blue yellow' });
+
+        const response = await client.spellcheck(index, "mellow");
+        console.log(response);
         expect(response.length).to.be.greaterThan(0, 'The response of the FT.SPELLCHECK command')
     })
-    it('dictadd function', async () => {
+    /* it('dictadd function', async () => {
         const response = await client.dictadd(dict.name, [dict.term])
         expect(response).to.equal(1, 'The response of the FT.DICTADD command')
     })
@@ -457,5 +464,5 @@ describe('RediSearch Module testing', async function () {
         }])
         const response = await client.dropindex(`${index}-droptest`)
         expect(response).to.equal('OK', 'The response of the FT.DROPINDEX command')
-    })
+    }) */
 })


### PR DESCRIPTION
Hi!

I accidentally made a mistake when making the last pull request.
```ts
// .length was used no matter whether it was a string or a string[], so
['param1', 'param2'].length == 2 //This was correct
// But a user might want to enter a string
'param1'.length == 6 //Is bad in this case, we only need to send "1"
```

Also changed the spellcheck module response parsing to objects like this:
```js
{
  term: "mellow",
  suggestions: [
    {
      score: 1,
      suggestion: "yellow"
    },
    {
      score: 1,
      suggestion: "mellon"
    }
  ]
}
```

This request is independent of #132, **can be merged if no issues are found.**
I will fix 132 in another pull request... (once I get the necessary test case(s) to reproduce it)