### PR TITLE
RediSearch bug fix Separator was misspelled as seperator

### DIFF
--- a/modules/redisearch/redisearch.commander.ts
+++ b/modules/redisearch/redisearch.commander.ts
@@ -5,7 +5,7 @@ import {
 import { CommandData } from "../module.base";
 
 export class SearchCommander {
-    
+
     /**
      * Creating an index with a given spec
      * @param index The index of the schema
@@ -75,7 +75,7 @@ export class SearchCommander {
             if(field.nostem === true) args.push('NOSTEM');
             if(field.weight !== undefined) args = args.concat(['WEIGHT', `${field.weight}`])
             if(field.phonetic !== undefined) args = args.concat(['PHONETIC', field.phonetic])
-            if(field.seperator !== undefined) args = args.concat(['SEPERATOR', field.seperator])
+            if(field.separator !== undefined) args = args.concat(['SEPARATOR', field.separator])
             if(field.sortable === true) args.push('SORTABLE')
             if(field.noindex === true) args.push('NOINDEX')
             if(field.unf === true) args.push('UNF')
@@ -179,8 +179,8 @@ export class SearchCommander {
                     args = args.concat(['FRAGS', `${parameters.summarize.frags}`])
                 if(parameters.summarize.len !== undefined)
                     args = args.concat(['LEN', `${parameters.summarize.len}`])
-                if(parameters.summarize.seperator !== undefined)
-                    args = args.concat(['SEPARATOR', parameters.summarize.seperator])
+                if(parameters.summarize.separator !== undefined)
+                    args = args.concat(['SEPARATOR', parameters.summarize.separator])
             }
             if(parameters.highlight !== undefined) {
                 args.push('HIGHLIGHT')
@@ -328,7 +328,7 @@ export class SearchCommander {
     }
 
     /**
-     * Retrieving the execution plan for a complex query but formatted for easier reading without using redis-cli --raw 
+     * Retrieving the execution plan for a complex query but formatted for easier reading without using redis-cli --raw
      * @param index The index
      * @param query The query
      * @returns A string representing the execution plan.
@@ -354,7 +354,7 @@ export class SearchCommander {
             if(options.nostem === true) args.push('NOSTEM')
             if(options.weight !== undefined) args = args.concat(['WEIGHT', `${options.weight}`])
             if(options.phonetic !== undefined) args = args.concat(['PHONETIC', options.phonetic])
-            if(options.seperator !== undefined) args = args.concat(['SEPERATOR', options.seperator])
+            if(options.separator !== undefined) args = args.concat(['SEPARATOR', options.separator])
             if(options.sortable === true) args.push('SORTABLE')
             if(options.noindex === true) args.push('NOINDEX')
             if(options.unf === true) args.push('UNF')
@@ -403,7 +403,7 @@ export class SearchCommander {
     aliasupdate(name: string, index: string): CommandData {
         return {
             command: 'FT.ALIASUPDATE',
-            args: [name, index]   
+            args: [name, index]
         }
     }
 
@@ -423,7 +423,7 @@ export class SearchCommander {
      * Retrieving the distinct tags indexed in a Tag field
      * @param index The index
      * @param field The field name
-     * @returns The distinct tags indexed in a Tag field 
+     * @returns The distinct tags indexed in a Tag field
      */
     tagvals(index: string, field: string): CommandData {
         return {
@@ -459,7 +459,7 @@ export class SearchCommander {
      * @param key The key
      * @param prefix The prefix of the suggestion
      * @param options The additional optional parameter
-     * @returns A list of the top suggestions matching the prefix, optionally with score after each entry 
+     * @returns A list of the top suggestions matching the prefix, optionally with score after each entry
      */
     sugget(key: string, prefix: string, options?: FTSugGetParameters): CommandData {
         let args = [key, prefix];
@@ -506,7 +506,7 @@ export class SearchCommander {
      * Updating a synonym group
      * @param index The index
      * @param groupId The group id
-     * @param terms A list of terms 
+     * @param terms A list of terms
      * @param skipInitialScan If set, we do not scan and index.
      * @returns 'OK'
      */
@@ -524,7 +524,7 @@ export class SearchCommander {
     /**
      * Dumps the contents of a synonym group
      * @param index The index
-     * @returns A list of synonym terms and their synonym group ids.  
+     * @returns A list of synonym terms and their synonym group ids.
      */
     syndump(index: string): CommandData {
         return {
@@ -599,7 +599,7 @@ export class SearchCommander {
     /**
      * Retrieving infromation and statistics on the index
      * @param index The index
-     * @returns A nested array of keys and values. 
+     * @returns A nested array of keys and values.
      */
     info(index: string): CommandData {
         return {

--- a/modules/redisearch/redisearch.types.ts
+++ b/modules/redisearch/redisearch.types.ts
@@ -22,7 +22,7 @@ export interface FTCreateParameters {
     * The 'TEMPORARY' parameter. Create a lightweight temporary index which will expire after the specified period of inactivity.
     */
     temporary?: number,
-    /** 
+    /**
     * The 'NOHL' parameter. Conserves storage space and memory by disabling highlighting support. If set, we do not store corresponding byte offsets for term positions.
     */
     nohl?: boolean,
@@ -35,7 +35,7 @@ export interface FTCreateParameters {
     */
     noFreqs?: boolean,
     /**
-    *  The 'SKIPINITIALSCAN' parameter. If set, we do not scan and index. 
+    *  The 'SKIPINITIALSCAN' parameter. If set, we do not scan and index.
     */
     skipInitialScan?: boolean
     /**
@@ -54,15 +54,15 @@ export interface FTCreateParameters {
     */
     languageField?: string,
     /**
-    * The 'SCORE' parameter. If set indicates the default score for documents in the index. 
+    * The 'SCORE' parameter. If set indicates the default score for documents in the index.
     */
     score?: string,
     /**
-    * The 'SCORE_FIELD' parameter. If set indicates the document field that should be used as the document's rank based on the user's ranking. 
+    * The 'SCORE_FIELD' parameter. If set indicates the document field that should be used as the document's rank based on the user's ranking.
     */
     scoreField?: string
     /**
-    * The 'STOPWORDS' parameter. If set, we set the index with a custom stopword list, to be ignored during indexing and search time. 
+    * The 'STOPWORDS' parameter. If set, we set the index with a custom stopword list, to be ignored during indexing and search time.
     */
     stopwords?: {
         num?: number,
@@ -95,11 +95,11 @@ export interface FTFieldOptions {
     */
     weight?: number,
     /**
-    * The 'SEPERATOR' parameter. For TAG fields, indicates how the text contained in the field is to be split into individual tags. The default is , . The value must be a single character.
+    * The 'SEPARATOR' parameter. For TAG fields, indicates how the text contained in the field is to be split into individual tags. The default is , . The value must be a single character.
     */
-    seperator?: string
+    separator?: string
     /**
-     * The 'UNF' parameter. By default, SORTABLE applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using UNF (un-normalized form) it is possible to disable the normalization and keep the original form of the value. 
+     * The 'UNF' parameter. By default, SORTABLE applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using UNF (un-normalized form) it is possible to disable the normalization and keep the original form of the value.
      */
     unf?: boolean,
     /**
@@ -139,7 +139,7 @@ export interface FTSearchParameters {
     */
     verbatim?: boolean,
     /**
-     * The 'noStopWords' parameter. If set, we do not filter stopwords from the query. 
+     * The 'noStopWords' parameter. If set, we do not filter stopwords from the query.
      */
     noStopWords?: boolean,
     /**
@@ -155,7 +155,7 @@ export interface FTSearchParameters {
      */
     withSortKeys?: boolean,
     /**
-     * The 'FILTER' parameter.  If set, and numeric_field is defined as a numeric field in FT.CREATE, we will limit results to those having numeric values ranging between min and max. min and max follow ZRANGE syntax, and can be -inf , +inf and use ( for exclusive ranges. 
+     * The 'FILTER' parameter.  If set, and numeric_field is defined as a numeric field in FT.CREATE, we will limit results to those having numeric values ranging between min and max. min and max follow ZRANGE syntax, and can be -inf , +inf and use ( for exclusive ranges.
      */
     filter?: {
         /**
@@ -220,14 +220,14 @@ export interface FTSearchParameters {
              * The name of the field.
              */
             field: string,
-            /** 
+            /**
              * The 'AS' parameter following a "field" name, used by index type "JSON".
             */
             as?: string,
         }[],
     },
     /**
-     * The 'SUMMARIZE' parameter. Use this option to return only the sections of the field which contain the matched text. 
+     * The 'SUMMARIZE' parameter. Use this option to return only the sections of the field which contain the matched text.
      */
     summarize?: {
         /**
@@ -246,9 +246,9 @@ export interface FTSearchParameters {
          */
         len?: number,
         /**
-         * The seperator argument of the 'SUMMARIZE' parameter
+         * The separator argument of the 'SUMMARIZE' parameter
          */
-        seperator?: string
+        separator?: string
     },
     /**
      * The 'HIGHLIGHT' parameter. Use this option to format occurrences of matched text.
@@ -280,7 +280,7 @@ export interface FTSearchParameters {
      */
     slop?: number,
     /**
-     * The 'INORDER' parameter. If set, and usually used in conjunction with SLOP, we make sure the query terms appear in the same order in the document as in the query, regardless of the offsets between them. 
+     * The 'INORDER' parameter. If set, and usually used in conjunction with SLOP, we make sure the query terms appear in the same order in the document as in the query, regardless of the offsets between them.
      */
     inOrder?: boolean,
     /**
@@ -341,7 +341,7 @@ export interface FTSearchParameters {
  */
 export interface FTAggregateParameters {
     /**
-     * The 'LOAD' parameter. 
+     * The 'LOAD' parameter.
      */
     load?: {
         /**
@@ -375,7 +375,7 @@ export interface FTAggregateParameters {
      */
     reduce?: FTReduce[],
     /**
-     * The 'SORTBY' parameter. 
+     * The 'SORTBY' parameter.
      */
     sortby?: {
         /**
@@ -631,7 +631,7 @@ export interface FTInfo {
  * The FT.SPELLCHECK response object
  */
 export interface FTSpellCheckResponse {
-    /** 
+    /**
      * The term that was spellchecked
     */
     term: string,

--- a/tests/redisearch.ts
+++ b/tests/redisearch.ts
@@ -254,13 +254,13 @@ describe('RediSearch Module testing', async function () {
                     fields: { fields: ['introduction'] },
                     frags: 1,
                     len: 3,
-                    seperator: ' !?!'
+                    separator: ' !?!'
                 }
             }
         )
         expect(res[0]).to.equal(2, 'Total number of returining document of FT.SEARCH command')
-        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
-        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize seperator')
+        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize separator')
+        expect((res[1] as {[key: string]: string}).introduction.endsWith('!?!')).to.equal(true, 'Custom summarize separator')
     })
     it('Search tests with highlight', async () => {
         const res = await redis.search_module_search(


### PR DESCRIPTION
Title fully summarizes what needed to be fixed. Relevant issue is here https://github.com/danitseitlin/redis-modules-sdk-ts/issues/181 

Redisearch tests pass.  There were some line ending cleanups that occurred as a result of my IDE.  Let me know if you want me to walk those changes back.  Is there any concern about the types for redisearch changing? Let me know if there is additional information required for the PR.