### PR TITLE
Fix range+revrange return types in Timeseries

### DIFF
--- a/modules/rts/rts.ts
+++ b/modules/rts/rts.ts
@@ -155,7 +155,7 @@ export class RedisTimeSeries extends Module {
      * @param options.aggregation.type The type of the 'AGGREGATION' command
      * @param options.aggregation.timeBucket The time bucket of the 'AGGREGATION' command
      */
-    async range(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): Promise<number[]> {
+    async range(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): Promise<[number, string][]> {
         const command = this.rtsCommander.range(key, fromTimestamp, toTimestamp, options);
         return await this.sendCommand(command);
     }
@@ -171,7 +171,7 @@ export class RedisTimeSeries extends Module {
      * @param options.aggregation.type The type of the 'AGGREGATION' command
      * @param options.aggregation.timeBucket The time bucket of the 'AGGREGATION' command
      */
-    async revrange(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): Promise<number[]> {
+    async revrange(key: string, fromTimestamp: string, toTimestamp: string, options?: TSRangeOptions): Promise<[number, string][]> {
         const command = this.rtsCommander.revrange(key, fromTimestamp, toTimestamp, options);
         return await this.sendCommand(command);
     }


### PR DESCRIPTION
The return types for range and revrange are wrong, they should be `[number, string][]` instead of `number[]`.

At a glance it looks like several other types are wrong here also, but I haven't looked into it too much.

The existing test suite still passes with these changes