### PR TITLE
Minor client updates

### DIFF
--- a/modules/rts/rts.commander.ts
+++ b/modules/rts/rts.commander.ts
@@ -1,5 +1,5 @@
 import { CommandData } from "../module.base";
-import { TSAddOptions, TSCreateOptions, TSCreateRule, TSIncrbyDecrbyOptions, TSKeySet, TSLabel, TSMRangeOptions, TSRangeOptions } from "./rts.types";
+import { TSAddOptions, TSCreateOptions, TSCreateRule, TSIncrbyDecrbyOptions, TSKeySet, TSLabel, TSMRangeOptions, TSRangeOptions, TSAlterOptions } from "./rts.types";
 
 export class RedisTimeSeriesCommander {
 
@@ -45,8 +45,10 @@ export class RedisTimeSeriesCommander {
      * @param chunkSize Optional. An update to the chunk size
      * 
      */
-    alter(key: string, retention?: number, labels?: TSLabel[], duplicatePolicy?: string, chunkSize?: number): CommandData {
+    alter(key: string, options?: TSAlterOptions): CommandData {
         let args = [key];
+        const {retention, labels, duplicatePolicy, chunkSize} = options;
+
         if(retention !== undefined)
             args = args.concat(['RETENTION', retention.toString()]);
         if(labels !== undefined && labels.length > 0) {

--- a/modules/rts/rts.commander.ts
+++ b/modules/rts/rts.commander.ts
@@ -55,10 +55,10 @@ export class RedisTimeSeriesCommander {
                 args = args.concat([label.name, label.value]);
             }
         }
-        if (duplicatePolicy !== undefined) {
+        if(duplicatePolicy !== undefined) {
                 args = args.concat(['DUPLICATE_POLICY', duplicatePolicy])
         }
-        if (chunkSize !== undefined) {
+        if(chunkSize !== undefined) {
             args = args.concat(['CHUNK_SIZE', chunkSize.toString()])
         }
         return {

--- a/modules/rts/rts.commander.ts
+++ b/modules/rts/rts.commander.ts
@@ -39,10 +39,10 @@ export class RedisTimeSeriesCommander {
     /**
      * Altering an existing TS key
      * @param key Required. The key
-     * @param retention Optional. The retention time
-     * @param labels Optional. The labels to update
-     * @param duplicatePolicy Optional. An update to the duplicate policy
-     * @param chunkSize Optional. An update to the chunk size
+     * @param options.retention Optional. The retention time
+     * @param options.labels Optional. The labels to update
+     * @param options.duplicatePolicy Optional. An update to the duplicate policy
+     * @param options.chunkSize Optional. An update to the chunk size
      * 
      */
     alter(key: string, options?: TSAlterOptions): CommandData {
@@ -61,7 +61,7 @@ export class RedisTimeSeriesCommander {
                 args = args.concat(['DUPLICATE_POLICY', duplicatePolicy])
         }
         if(chunkSize !== undefined) {
-            args = args.concat(['CHUNK_SIZE', chunkSize.toString()])
+            args = args.concat(['CHUNK_SIZE', `${chunkSize}`])
         }
         return {
             command: 'TS.ALTER',

--- a/modules/rts/rts.commander.ts
+++ b/modules/rts/rts.commander.ts
@@ -41,9 +41,11 @@ export class RedisTimeSeriesCommander {
      * @param key Required. The key
      * @param retention Optional. The retention time
      * @param labels Optional. The labels to update
+     * @param duplicatePolicy Optional. An update to the duplicate policy
+     * @param chunkSize Optional. An update to the chunk size
      * 
      */
-    alter(key: string, retention?: number, labels?: TSLabel[]): CommandData {
+    alter(key: string, retention?: number, labels?: TSLabel[], duplicatePolicy?: string, chunkSize?: number): CommandData {
         let args = [key];
         if(retention !== undefined)
             args = args.concat(['RETENTION', retention.toString()]);
@@ -52,6 +54,12 @@ export class RedisTimeSeriesCommander {
             for(const label of labels) {
                 args = args.concat([label.name, label.value]);
             }
+        }
+        if (duplicatePolicy !== undefined) {
+                args = args.concat(['DUPLICATE_POLICY', duplicatePolicy])
+        }
+        if (chunkSize !== undefined) {
+            args = args.concat(['CHUNK_SIZE', chunkSize.toString()])
         }
         return {
             command: 'TS.ALTER',

--- a/modules/rts/rts.commander.ts
+++ b/modules/rts/rts.commander.ts
@@ -394,7 +394,7 @@ export class RedisTimeSeriesCommander {
     queryindex(filter: string): CommandData {
         return {
             command: 'TS.QUERYINDEX',
-            args: [filter]
+            args: filter.split(' ')
         }
     }
 

--- a/modules/rts/rts.ts
+++ b/modules/rts/rts.ts
@@ -55,8 +55,8 @@ export class RedisTimeSeries extends Module {
      * @param labels Optional. The labels to update
      * 
      */
-    async alter(key: string, retention?: number, labels?: TSLabel[]): Promise<'OK'> {
-        const command = this.rtsCommander.alter(key, retention, labels);
+    async alter(key: string, retention?: number, labels?: TSLabel[], duplicatePolicy?: string, chunkSize?: number): Promise<'OK'> {
+        const command = this.rtsCommander.alter(key, retention, labels, duplicatePolicy, chunkSize);
         return await this.sendCommand(command);
     }
 

--- a/modules/rts/rts.ts
+++ b/modules/rts/rts.ts
@@ -2,7 +2,7 @@ import * as Redis from 'ioredis';
 import { Module, RedisModuleOptions } from '../module.base';
 import { RedisTimeSeriesCommander } from './rts.commander';
 import {
-    TSAddOptions, TSCreateOptions, TSCreateRule, TSIncrbyDecrbyOptions, TSInfo, TSKeySet, TSLabel,
+    TSAddOptions, TSAlterOptions, TSCreateOptions, TSCreateRule, TSIncrbyDecrbyOptions, TSInfo, TSKeySet,
     TSMRangeOptions, TSRangeOptions
 } from './rts.types';
 
@@ -55,8 +55,8 @@ export class RedisTimeSeries extends Module {
      * @param labels Optional. The labels to update
      * 
      */
-    async alter(key: string, retention?: number, labels?: TSLabel[], duplicatePolicy?: string, chunkSize?: number): Promise<'OK'> {
-        const command = this.rtsCommander.alter(key, retention, labels, duplicatePolicy, chunkSize);
+    async alter(key: string, options?: TSAlterOptions): Promise<'OK'> {
+        const command = this.rtsCommander.alter(key, options);
         return await this.sendCommand(command);
     }
 

--- a/modules/rts/rts.ts
+++ b/modules/rts/rts.ts
@@ -51,8 +51,10 @@ export class RedisTimeSeries extends Module {
     /**
      * Altering an existing TS key
      * @param key Required. The key
-     * @param retention Optional. The retention time
-     * @param labels Optional. The labels to update
+     * @param options.onDuplicate The 'ON_DUPLICATE' optional parameter
+     * @param options.retention The 'RETENTION' optional parameter
+     * @param options.chunkSize The 'CHUNK_SIZE' optional parameter
+     * @param options.labels A list of 'LABELS' optional parameter
      * 
      */
     async alter(key: string, options?: TSAlterOptions): Promise<'OK'> {

--- a/modules/rts/rts.types.ts
+++ b/modules/rts/rts.types.ts
@@ -20,7 +20,7 @@ export type TSInfo = {
     retentionTime?: number,
     chunkCount?: number,
     chunkSize?: number,
-    duplicatePolicy?: string | null,
+    duplicatePolicy?: TSDuplicatePolicyType,
     labels?: Array<string[]>,
     sourceKey?: string | null,
     rules?: Array<string[]>,
@@ -35,7 +35,7 @@ export type TSInfo = {
  * @param duplicatePolicy The 'DUPLICATE_POLICY' optional parameter
  */
 export interface TSCreateOptions extends TSOptions {
-    duplicatePolicy?: string
+    duplicatePolicy?: TSDuplicatePolicyType
 }
 /**
  * The label object

--- a/modules/rts/rts.types.ts
+++ b/modules/rts/rts.types.ts
@@ -20,7 +20,7 @@ export type TSInfo = {
     retentionTime?: number,
     chunkCount?: number,
     chunkSize?: number,
-    duplicatePolicy?: boolean | null,
+    duplicatePolicy?: string | null,
     labels?: Array<string[]>,
     sourceKey?: string | null,
     rules?: Array<string[]>,

--- a/modules/rts/rts.types.ts
+++ b/modules/rts/rts.types.ts
@@ -37,7 +37,6 @@ export type TSInfo = {
 export interface TSCreateOptions extends TSOptions {
     duplicatePolicy?: string
 }
-
 /**
  * The label object
  * @param name The name of the label
@@ -58,6 +57,20 @@ export type TSLabel = {
  */
 export interface TSAddOptions extends TSOptions {
     onDuplicate?: TSDuplicatePolicyType 
+}
+
+/** 
+* The 'TS.ALTER' command optional parameters
+* @param retention The 'RETENTION' optional parameter
+* @param chunkSize The 'CHUNK_SIZE' optional parameter
+* @param duplicatePolicy The DUPLICATE_POLICY optional parameter
+* @param labels A list of 'LABELS' optional parameter
+*/
+export type TSAlterOptions = {
+    retention?: number, 
+    chunkSize?: number,
+    duplicatePolicy?: TSDuplicatePolicyType, 
+    labels?: TSLabel[]
 }
 
 /**
@@ -102,6 +115,8 @@ export interface TSIncrbyDecrbyOptions extends TSOptions {
  * @param chunkSize The 'CHUNK_SIZE' optional parameter
  * @param labels A list of 'LABELS' optional parameter
  */
+
+
 export type TSOptions = {
     retention?: number,
     uncompressed?: boolean,

--- a/modules/rts/rts.types.ts
+++ b/modules/rts/rts.types.ts
@@ -116,7 +116,6 @@ export interface TSIncrbyDecrbyOptions extends TSOptions {
  * @param labels A list of 'LABELS' optional parameter
  */
 
-
 export type TSOptions = {
     retention?: number,
     uncompressed?: boolean,

--- a/tests/rts.ts
+++ b/tests/rts.ts
@@ -35,7 +35,7 @@ describe('RTS Module testing', async function() {
     });
     
     it('alter function', async () => {
-        const response = await redis.rts_module_alter(key1, 1);
+        const response = await redis.rts_module_alter(key1,{retention: 1});
         expect(response).to.equal('OK', 'The response of the alter command');
     });
     it('add function', async () => {


### PR DESCRIPTION
1. Enhancement: Adds support to update duplicatePolicy, chunkSize in TS.ALTER calls: [TS.ALTER](https://redis.io/commands/ts.alter/)

2. Bug Fix: Changes duplicate policy from boolean | undefined to string | undefined:  [TS.INFO](https://redis.io/commands/ts.alter/)

3. Bug Fix: Allows a list of args for TS.QUERYINDEX [TS.QUERYINDEX](https://redis.io/commands/ts.queryindex/)